### PR TITLE
[src] added docker swarm integration support

### DIFF
--- a/service/elastigroup/providers/aws/aws.go
+++ b/service/elastigroup/providers/aws/aws.go
@@ -101,6 +101,7 @@ type Integration struct {
 	Chef                *ChefIntegration                `json:"chef,omitempty"`
 	Gitlab              *GitlabIntegration              `json:"gitlab,omitempty"`
 	Route53             *Route53Integration             `json:"route53,omitempty"`
+	DockerSwarm         *DockerSwarmIntegration         `json:"dockerSwarm,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -137,6 +138,13 @@ type AutoScaleKubernetes struct {
 type AutoScaleNomad struct {
 	AutoScale                          // embedding
 	Constraints []*AutoScaleConstraint `json:"constraints,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+type AutoScaleDockerSwarm struct {
+	AutoScale // embedding
 
 	forceSendFields []string
 	nullFields      []string
@@ -183,7 +191,7 @@ type AutoScaleAttributes struct {
 }
 
 type ElasticBeanstalkIntegration struct {
-	EnvironmentID *string `json:"environmentId,omitempty"`
+	EnvironmentID         *string                `json:"environmentId,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -272,6 +280,15 @@ type ChefIntegration struct {
 	User         *string `json:"user,omitempty"`
 	PEMKey       *string `json:"pemKey,omitempty"`
 	Version      *string `json:"chefVersion,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+type DockerSwarmIntegration struct {
+	MasterHost           *string               `json:"masterHost,omitempty"`
+	MasterPort           *int                  `json:"masterPort,omitempty"`
+	AutoScaleDockerSwarm *AutoScaleDockerSwarm `json:"autoScale,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1076,6 +1093,13 @@ func (o *Integration) SetRoute53(v *Route53Integration) *Integration {
 	return o
 }
 
+func (o *Integration) SetDockerSwarm(v *DockerSwarmIntegration) *Integration {
+	if o.DockerSwarm = v; o.DockerSwarm == nil {
+		o.nullFields = append(o.nullFields, "DockerSwarm")
+	}
+	return o
+}
+
 func (o *Integration) SetEC2ContainerService(v *EC2ContainerServiceIntegration) *Integration {
 	if o.EC2ContainerService = v; o.EC2ContainerService == nil {
 		o.nullFields = append(o.nullFields, "EC2ContainerService")
@@ -1194,7 +1218,7 @@ func (o *ElasticBeanstalkIntegration) MarshalJSON() ([]byte, error) {
 	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
 }
 
-func (o *ElasticBeanstalkIntegration) SetEnvironmentId(v *string) *ElasticBeanstalkIntegration {
+func (o *ElasticBeanstalkIntegration) SetEnvironmentID(v *string) *ElasticBeanstalkIntegration {
 	if o.EnvironmentID = v; o.EnvironmentID == nil {
 		o.nullFields = append(o.nullFields, "EnvironmentID")
 	}
@@ -1246,6 +1270,43 @@ func (o *AutoScaleECS) SetShouldScaleDownNonServiceTasks(v *bool) *AutoScaleECS 
 }
 
 // endregion
+
+// region Docker Swarm
+
+func (o *DockerSwarmIntegration) MarshalJSON() ([]byte, error) {
+	type noMethod DockerSwarmIntegration
+	raw := noMethod(*o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+func (o *DockerSwarmIntegration) SetMasterHost(v *string) *DockerSwarmIntegration {
+	if o.MasterHost = v; o.MasterHost == nil {
+		o.nullFields = append(o.nullFields, "MasterHost")
+	}
+	return o
+}
+
+func (o *DockerSwarmIntegration) SetMasterPort(v *int) *DockerSwarmIntegration {
+	if o.MasterPort = v; o.MasterPort == nil {
+		o.nullFields = append(o.nullFields, "MasterPort")
+	}
+	return o
+}
+
+func (o *DockerSwarmIntegration) SetAutoScaleDockerSwarm(v *AutoScaleDockerSwarm) *DockerSwarmIntegration {
+	if o.AutoScaleDockerSwarm = v; o.AutoScaleDockerSwarm == nil {
+		o.nullFields = append(o.nullFields, "AutoScaleDockerSwarm")
+	}
+	return o
+}
+
+func (o *AutoScaleDockerSwarm) MarshalJSON() ([]byte, error) {
+	type noMethod AutoScaleDockerSwarm
+	raw := noMethod(*o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+// end region
 
 // region Route53
 


### PR DESCRIPTION
- fixed beanstalk syntax (environmentId -> environmentID). This aligns it with the rest of the codebase.