### PR TITLE
aws, gcp, azure updates

### DIFF
--- a/service/elastigroup/providers/aws/aws.go
+++ b/service/elastigroup/providers/aws/aws.go
@@ -210,14 +210,14 @@ type ElasticBeanstalkIntegration struct {
 	nullFields      []string
 }
 
-type BeanstalkManagedActions struct{
+type BeanstalkManagedActions struct {
 	PlatformUpdate *BeanstalkPlatformUpdate `json:"platformUpdate,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
 }
 
-type BeanstalkPlatformUpdate struct{
+type BeanstalkPlatformUpdate struct {
 	PerformAt   *string `json:"performAt,omitempty"`
 	TimeWindow  *string `json:"timeWindow,omitempty"`
 	UpdateLevel *string `json:"updateLevel,omitempty"`
@@ -226,7 +226,7 @@ type BeanstalkPlatformUpdate struct{
 	nullFields      []string
 }
 
-type BeanstalkDeploymentPreferences struct{
+type BeanstalkDeploymentPreferences struct {
 	AutomaticRoll       *bool                        `json:"automaticRoll,omitempty"`
 	BatchSizePercentage *int                         `json:"batchSizePercentage,omitempty"`
 	GracePeriod         *int                         `json:"gracePeriod,omitempty"`
@@ -236,7 +236,7 @@ type BeanstalkDeploymentPreferences struct{
 	nullFields      []string
 }
 
-type BeanstalkDeploymentStrategy struct{
+type BeanstalkDeploymentStrategy struct {
 	Action               *string `json:"action,omitempty"`
 	ShouldDrainInstances *bool   `json:"shouldDrainInstances,omitempty"`
 
@@ -350,8 +350,9 @@ type Route53Integration struct {
 }
 
 type Domain struct {
-	HostedZoneID *string      `json:"hostedZoneId,omitempty"`
-	RecordSets   []*RecordSet `json:"recordSets,omitempty"`
+	HostedZoneID      *string      `json:"hostedZoneId,omitempty"`
+	SpotinstAccountID *string      `json:"spotinstAccountId,omitempty"`
+	RecordSets        []*RecordSet `json:"recordSets,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1245,9 +1246,9 @@ func (s *ServiceOp) ImportBeanstalkEnv(ctx context.Context, input *ImportBeansta
 	path := "/aws/ec2/group/beanstalk/import"
 	r := client.NewRequest(http.MethodGet, path)
 
-	if input.EnvironmentId != nil{
+	if input.EnvironmentId != nil {
 		r.Params["environmentId"] = []string{spotinst.StringValue(input.EnvironmentId)}
-	}else if input.EnvironmentName != nil{
+	} else if input.EnvironmentName != nil {
 		r.Params["environmentName"] = []string{spotinst.StringValue(input.EnvironmentName)}
 	}
 
@@ -1573,14 +1574,14 @@ func (o *ElasticBeanstalkIntegration) SetEnvironmentID(v *string) *ElasticBeanst
 }
 
 func (o *ElasticBeanstalkIntegration) SetManagedActions(v *BeanstalkManagedActions) *ElasticBeanstalkIntegration {
-	if o.ManagedActions = v; o.ManagedActions == nil{
+	if o.ManagedActions = v; o.ManagedActions == nil {
 		o.nullFields = append(o.nullFields, "ManagedActions")
 	}
 	return o
 }
 
 func (o *ElasticBeanstalkIntegration) SetDeploymentPreferences(v *BeanstalkDeploymentPreferences) *ElasticBeanstalkIntegration {
-	if o.DeploymentPreferences = v; o.DeploymentPreferences == nil{
+	if o.DeploymentPreferences = v; o.DeploymentPreferences == nil {
 		o.nullFields = append(o.nullFields, "DeploymentPreferences")
 	}
 	return o
@@ -1596,11 +1597,12 @@ func (o *BeanstalkManagedActions) MarshalJSON() ([]byte, error) {
 }
 
 func (o *BeanstalkManagedActions) SetPlatformUpdate(v *BeanstalkPlatformUpdate) *BeanstalkManagedActions {
-	if o.PlatformUpdate = v; o.PlatformUpdate == nil{
+	if o.PlatformUpdate = v; o.PlatformUpdate == nil {
 		o.nullFields = append(o.nullFields, "PlatformUpdate")
 	}
 	return o
 }
+
 // endregion
 
 // region BeanstalkPlatformUpdate
@@ -1611,21 +1613,21 @@ func (o *BeanstalkPlatformUpdate) MarshalJSON() ([]byte, error) {
 }
 
 func (o *BeanstalkPlatformUpdate) SetPerformAt(v *string) *BeanstalkPlatformUpdate {
-	if o.PerformAt = v; o.PerformAt == nil{
+	if o.PerformAt = v; o.PerformAt == nil {
 		o.nullFields = append(o.nullFields, "PerformAt")
 	}
 	return o
 }
 
 func (o *BeanstalkPlatformUpdate) SetTimeWindow(v *string) *BeanstalkPlatformUpdate {
-	if o.TimeWindow = v; o.TimeWindow == nil{
+	if o.TimeWindow = v; o.TimeWindow == nil {
 		o.nullFields = append(o.nullFields, "TimeWindow")
 	}
 	return o
 }
 
 func (o *BeanstalkPlatformUpdate) SetUpdateLevel(v *string) *BeanstalkPlatformUpdate {
-	if o.UpdateLevel = v; o.UpdateLevel == nil{
+	if o.UpdateLevel = v; o.UpdateLevel == nil {
 		o.nullFields = append(o.nullFields, "UpdateLevel")
 	}
 	return o
@@ -1641,32 +1643,33 @@ func (o *BeanstalkDeploymentPreferences) MarshalJSON() ([]byte, error) {
 }
 
 func (o *BeanstalkDeploymentPreferences) SetAutomaticRoll(v *bool) *BeanstalkDeploymentPreferences {
-	if o.AutomaticRoll = v; o.AutomaticRoll == nil{
+	if o.AutomaticRoll = v; o.AutomaticRoll == nil {
 		o.nullFields = append(o.nullFields, "AutomaticRoll")
 	}
 	return o
 }
 
 func (o *BeanstalkDeploymentPreferences) SetBatchSizePercentage(v *int) *BeanstalkDeploymentPreferences {
-	if o.BatchSizePercentage = v; o.BatchSizePercentage == nil{
+	if o.BatchSizePercentage = v; o.BatchSizePercentage == nil {
 		o.nullFields = append(o.nullFields, "BatchSizePercentage")
 	}
 	return o
 }
 
 func (o *BeanstalkDeploymentPreferences) SetGracePeriod(v *int) *BeanstalkDeploymentPreferences {
-	if o.GracePeriod = v; o.GracePeriod == nil{
+	if o.GracePeriod = v; o.GracePeriod == nil {
 		o.nullFields = append(o.nullFields, "GracePeriod")
 	}
 	return o
 }
 
 func (o *BeanstalkDeploymentPreferences) SetStrategy(v *BeanstalkDeploymentStrategy) *BeanstalkDeploymentPreferences {
-	if o.Strategy = v; o.Strategy == nil{
+	if o.Strategy = v; o.Strategy == nil {
 		o.nullFields = append(o.nullFields, "Strategy")
 	}
 	return o
 }
+
 // endregion
 
 // region BeanstalkDeploymentStrategy
@@ -1677,18 +1680,19 @@ func (o *BeanstalkDeploymentStrategy) MarshalJSON() ([]byte, error) {
 }
 
 func (o *BeanstalkDeploymentStrategy) SetAction(v *string) *BeanstalkDeploymentStrategy {
-	if o.Action = v; o.Action == nil{
+	if o.Action = v; o.Action == nil {
 		o.nullFields = append(o.nullFields, "Action")
 	}
 	return o
 }
 
 func (o *BeanstalkDeploymentStrategy) SetShouldDrainInstances(v *bool) *BeanstalkDeploymentStrategy {
-	if o.ShouldDrainInstances = v; o.ShouldDrainInstances == nil{
+	if o.ShouldDrainInstances = v; o.ShouldDrainInstances == nil {
 		o.nullFields = append(o.nullFields, "ShouldDrainInstances")
 	}
 	return o
 }
+
 // endregion
 
 // region EC2ContainerServiceIntegration
@@ -1800,6 +1804,14 @@ func (o *Domain) MarshalJSON() ([]byte, error) {
 func (o *Domain) SetHostedZoneID(v *string) *Domain {
 	if o.HostedZoneID = v; o.HostedZoneID == nil {
 		o.nullFields = append(o.nullFields, "HostedZoneID")
+	}
+	return o
+}
+
+// SetSpotinstAccountID sets the spotinst account ID for us in cross-account linking
+func (o *Domain) SetSpotinstAccountID(v *string) *Domain {
+	if o.SpotinstAccountID = v; o.SpotinstAccountID == nil {
+		o.nullFields = append(o.nullFields, "SpotinstAccountID")
 	}
 	return o
 }

--- a/service/elastigroup/providers/aws/aws.go
+++ b/service/elastigroup/providers/aws/aws.go
@@ -675,8 +675,9 @@ type Instance struct {
 }
 
 type RollStrategy struct {
-	Action               *string `json:"action,omitempty"`
-	ShouldDrainInstances *bool   `json:"shouldDrainInstances,omitempty"`
+	Action                    *string `json:"action,omitempty"`
+	ShouldDrainInstances      *bool   `json:"shouldDrainInstances,omitempty"`
+	BatchMinHealthyPercentage *int    `json:"batchMinHealthyPercentage,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string

--- a/service/elastigroup/providers/azure/azure.go
+++ b/service/elastigroup/providers/azure/azure.go
@@ -185,6 +185,7 @@ type LaunchSpecification struct {
 	LoadBalancersConfig *LoadBalancersConfig `json:"loadBalancersConfig,omitempty"`
 	Image               *Image               `json:"image,omitempty"`
 	UserData            *string              `json:"userData,omitempty"`
+	ShutdownScript      *string              `json:"shutdownScript,omitempty"`
 	Storage             *Storage             `json:"storage,omitempty"`
 	Network             *Network             `json:"network,omitempty"`
 	Login               *Login               `json:"login,omitempty"`
@@ -1813,6 +1814,14 @@ func (o *LaunchSpecification) SetImage(v *Image) *LaunchSpecification {
 func (o *LaunchSpecification) SetUserData(v *string) *LaunchSpecification {
 	if o.UserData = v; o.UserData == nil {
 		o.nullFields = append(o.nullFields, "UserData")
+	}
+	return o
+}
+
+// SetShutdownScript sets the shutdown script used when draining instances
+func (o *LaunchSpecification) SetShutdownScript(v *string) *LaunchSpecification {
+	if o.ShutdownScript = v; o.ShutdownScript == nil {
+		o.nullFields = append(o.nullFields, "ShutdownScript")
 	}
 	return o
 }

--- a/service/elastigroup/providers/azure/azure.go
+++ b/service/elastigroup/providers/azure/azure.go
@@ -52,7 +52,23 @@ type Scheduling struct {
 }
 
 type Integration struct {
-	Rancher *RancherIntegration `json:"rancher,omitempty"`
+	Rancher    *RancherIntegration    `json:"rancher,omitempty"`
+	Kubernetes *KubernetesIntegration `json:"kubernetes,omitempty"`
+	Multai     *MultaiIntegration     `json:"mlbRuntime,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+type KubernetesIntegration struct {
+	ClusterIdentifier *string `json:"clusterIdentifier,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+type MultaiIntegration struct {
+	DeploymentID *string `json:"deploymentId,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -252,10 +268,19 @@ type Storage struct {
 }
 
 type Network struct {
-	VirtualNetworkName *string `json:"virtualNetworkName,omitempty"`
-	SubnetName         *string `json:"subnetName,omitempty"`
-	ResourceGroupName  *string `json:"resourceGroupName,omitempty"`
-	AssignPublicIP     *bool   `json:"assignPublicIp,omitempty"`
+	VirtualNetworkName  *string                `json:"virtualNetworkName,omitempty"`
+	SubnetName          *string                `json:"subnetName,omitempty"`
+	ResourceGroupName   *string                `json:"resourceGroupName,omitempty"`
+	AssignPublicIP      *bool                  `json:"assignPublicIp,omitempty"`
+	AdditionalIPConfigs []*AdditionalIPConfigs `json:"additionalIpConfigurations,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+type AdditionalIPConfigs struct {
+	Name                    *string `json:"name,omitempty"`
+	PrivateIPAddressVersion *string `json:"privateIpAddressVersion,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1271,9 +1296,57 @@ func (o *Integration) MarshalJSON() ([]byte, error) {
 	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
 }
 
+func (o *Integration) SetKubernetes(v *KubernetesIntegration) *Integration {
+	if o.Kubernetes = v; o.Kubernetes == nil {
+		o.nullFields = append(o.nullFields, "Kubernetes")
+	}
+	return o
+}
+
+func (o *Integration) SetMultai(v *MultaiIntegration) *Integration {
+	if o.Multai = v; o.Multai == nil {
+		o.nullFields = append(o.nullFields, "Multai")
+	}
+	return o
+}
+
 func (o *Integration) SetRancher(v *RancherIntegration) *Integration {
 	if o.Rancher = v; o.Rancher == nil {
 		o.nullFields = append(o.nullFields, "Rancher")
+	}
+	return o
+}
+
+// endregion
+
+// region KubernetesIntegration
+
+func (o *KubernetesIntegration) MarshalJSON() ([]byte, error) {
+	type noMethod KubernetesIntegration
+	raw := noMethod(*o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+func (o *KubernetesIntegration) SetClusterIdentifier(v *string) *KubernetesIntegration {
+	if o.ClusterIdentifier = v; o.ClusterIdentifier == nil {
+		o.nullFields = append(o.nullFields, "ClusterIdentifier")
+	}
+	return o
+}
+
+// endregion
+
+// region MultaiIntegration
+
+func (o *MultaiIntegration) MarshalJSON() ([]byte, error) {
+	type noMethod MultaiIntegration
+	raw := noMethod(*o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+func (o *MultaiIntegration) SetDeploymentId(v *string) *MultaiIntegration {
+	if o.DeploymentID = v; o.DeploymentID == nil {
+		o.nullFields = append(o.nullFields, "DeploymentID")
 	}
 	return o
 }
@@ -2060,6 +2133,14 @@ func (o *Network) SetAssignPublicIP(v *bool) *Network {
 	return o
 }
 
+// SetAdditionalIPConfigs sets the additional IP configurations
+func (o *Network) SetAdditionalIPConfigs(v []*AdditionalIPConfigs) *Network {
+	if o.AdditionalIPConfigs = v; o.AdditionalIPConfigs == nil {
+		o.nullFields = append(o.nullFields, "AdditionalIPConfigs")
+	}
+	return o
+}
+
 // endregion
 
 // region Login
@@ -2087,6 +2168,32 @@ func (o *Login) SetSSHPublicKey(v *string) *Login {
 func (o *Login) SetPassword(v *string) *Login {
 	if o.Password = v; o.Password == nil {
 		o.nullFields = append(o.nullFields, "Password")
+	}
+	return o
+}
+
+// endregion
+
+// region AdditionalIPConfigs
+
+func (o *AdditionalIPConfigs) MarshalJSON() ([]byte, error) {
+	type noMethod AdditionalIPConfigs
+	raw := noMethod(*o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+// SetName sets the name
+func (o *AdditionalIPConfigs) SetName(v *string) *AdditionalIPConfigs {
+	if o.Name = v; o.Name == nil {
+		o.nullFields = append(o.nullFields, "Name")
+	}
+	return o
+}
+
+// SetPrivateIPAddressVersion sets the ip address version
+func (o *AdditionalIPConfigs) SetPrivateIPAddressVersion(v *string) *AdditionalIPConfigs {
+	if o.PrivateIPAddressVersion = v; o.PrivateIPAddressVersion == nil {
+		o.nullFields = append(o.nullFields, "PrivateIPAddressVersion")
 	}
 	return o
 }

--- a/service/elastigroup/providers/gcp/gcp.go
+++ b/service/elastigroup/providers/gcp/gcp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/spotinst/spotinst-sdk-go/spotinst"
@@ -386,6 +387,7 @@ type GKEIntegration struct {
 	ClusterID       *string       `json:"clusterID,omitempty"`
 	ClusterZoneName *string       `json:"clusterZoneName,omitempty"`
 	AutoScale       *AutoScaleGKE `json:"autoScale,omitempty"`
+	Location        *string       `json:"location"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -439,6 +441,7 @@ type DeleteGroupOutput struct{}
 type ImportGKEClusterInput struct {
 	ClusterID       *string         `json:"clusterID,omitempty"`
 	ClusterZoneName *string         `json:"clusterZoneName,omitempty"`
+	DryRun          *bool           `json:"dryRun,omitempty"`
 	Group           *ImportGKEGroup `json:"group,omitempty"`
 }
 
@@ -632,6 +635,7 @@ func (s *ServiceOp) ImportGKECluster(ctx context.Context, input *ImportGKECluste
 
 	r.Params["clusterId"] = []string{spotinst.StringValue(input.ClusterID)}
 	r.Params["zone"] = []string{spotinst.StringValue(input.ClusterZoneName)}
+	r.Params["dryRun"] = []string{strconv.FormatBool(spotinst.BoolValue(input.DryRun))}
 
 	body := &ImportGKEClusterInput{Group: input.Group}
 	r.Obj = body

--- a/service/elastigroup/providers/gcp/gcp.go
+++ b/service/elastigroup/providers/gcp/gcp.go
@@ -372,7 +372,8 @@ type Strategy struct {
 // region Integration structs
 
 type Integration struct {
-	GKE *GKEIntegration `json:"gke,omitempty"`
+	GKE         *GKEIntegration         `json:"gke,omitempty"`
+	DockerSwarm *DockerSwarmIntegration `json:"dockerSwarm,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -392,6 +393,18 @@ type GKEIntegration struct {
 type AutoScaleGKE struct {
 	AutoScale                   // embedding
 	Labels    []*AutoScaleLabel `json:"labels,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+// endregion
+
+// region DockerSwarmIntegration structs
+
+type DockerSwarmIntegration struct {
+	MasterHost *string `json:"masterHost,omitempty"`
+	MasterPort *int    `json:"masterPort,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1653,6 +1666,14 @@ func (o *Integration) SetGKE(v *GKEIntegration) *Integration {
 	return o
 }
 
+// SetDockerSwarm sets the DockerSwarm integration
+func (o *Integration) SetDockerSwarm(v *DockerSwarmIntegration) *Integration {
+	if o.DockerSwarm = v; o.DockerSwarm == nil {
+		o.nullFields = append(o.nullFields, "DockerSwarm")
+	}
+	return o
+}
+
 // region GKE integration setters
 
 func (o *GKEIntegration) MarshalJSON() ([]byte, error) {
@@ -1686,6 +1707,32 @@ func (o *AutoScaleGKE) SetLabels(v []*AutoScaleLabel) *AutoScaleGKE {
 }
 
 // endregion
+
+// endregion
+
+// region DockerSwarm integration setters
+
+func (o *DockerSwarmIntegration) MarshalJSON() ([]byte, error) {
+	type noMethod DockerSwarmIntegration
+	raw := noMethod(*o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+// SetMasterPort sets the master port
+func (o *DockerSwarmIntegration) SetMasterPort(v *int) *DockerSwarmIntegration {
+	if o.MasterPort = v; o.MasterPort == nil {
+		o.nullFields = append(o.nullFields, "MasterPort")
+	}
+	return o
+}
+
+// SetMasterHost sets the master host
+func (o *DockerSwarmIntegration) SetMasterHost(v *string) *DockerSwarmIntegration {
+	if o.MasterHost = v; o.MasterHost == nil {
+		o.nullFields = append(o.nullFields, "MasterHost")
+	}
+	return o
+}
 
 // endregion
 

--- a/service/elastigroup/providers/gcp/gcp.go
+++ b/service/elastigroup/providers/gcp/gcp.go
@@ -384,10 +384,11 @@ type Integration struct {
 // region GKEIntegration structs
 
 type GKEIntegration struct {
-	ClusterID       *string       `json:"clusterID,omitempty"`
+	ClusterID       *string       `json:"clusterIdentifier,omitempty"`
 	ClusterZoneName *string       `json:"clusterZoneName,omitempty"`
+	AutoUpdate      *bool         `json:"autoUpdate,omitempty"`
 	AutoScale       *AutoScaleGKE `json:"autoScale,omitempty"`
-	Location        *string       `json:"location"`
+	Location        *string       `json:"location,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1703,10 +1704,34 @@ func (o *GKEIntegration) MarshalJSON() ([]byte, error) {
 	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
 }
 
+// SetAutoUpdate sets the autoupdate flag
+func (o *GKEIntegration) SetAutoUpdate(v *bool) *GKEIntegration {
+	if o.AutoUpdate = v; o.AutoUpdate == nil {
+		o.nullFields = append(o.nullFields, "AutoUpdate")
+	}
+	return o
+}
+
 // SetAutoScale sets the AutoScale configuration used with the GKE integration
 func (o *GKEIntegration) SetAutoScale(v *AutoScaleGKE) *GKEIntegration {
 	if o.AutoScale = v; o.AutoScale == nil {
 		o.nullFields = append(o.nullFields, "AutoScale")
+	}
+	return o
+}
+
+// SetLocation sets the location that the cluster is located in
+func (o *GKEIntegration) SetLocation(v *string) *GKEIntegration {
+	if o.Location = v; o.Location == nil {
+		o.nullFields = append(o.nullFields, "Location")
+	}
+	return o
+}
+
+// SetClusterID sets the cluster ID
+func (o *GKEIntegration) SetClusterID(v *string) *GKEIntegration {
+	if o.ClusterID = v; o.ClusterID == nil {
+		o.nullFields = append(o.nullFields, "ClusterID")
 	}
 	return o
 }

--- a/service/elastigroup/providers/gcp/gcp.go
+++ b/service/elastigroup/providers/gcp/gcp.go
@@ -119,7 +119,6 @@ type AliasIPRange struct {
 // BackendServiceConfig constains a list of backend service configurations.
 type BackendServiceConfig struct {
 	BackendServices []*BackendService `json:"backendServices,omitempty"`
-
 	forceSendFields []string
 	nullFields      []string
 }
@@ -127,6 +126,8 @@ type BackendServiceConfig struct {
 // BackendService defines the configuration for a single backend service.
 type BackendService struct {
 	BackendServiceName *string     `json:"backendServiceName,omitempty"`
+	LocationType       *string     `json:"locationType,omitempty"`
+	Scheme             *string     `json:"scheme,omitempty"`
 	NamedPorts         *NamedPorts `json:"namedPorts,omitempty"`
 
 	forceSendFields []string
@@ -1252,6 +1253,22 @@ func (o *BackendService) MarshalJSON() ([]byte, error) {
 func (o *BackendService) SetBackendServiceName(v *string) *BackendService {
 	if o.BackendServiceName = v; o.BackendServiceName == nil {
 		o.nullFields = append(o.nullFields, "BackendServiceName")
+	}
+	return o
+}
+
+// SetLocationType sets the location type
+func (o *BackendService) SetLocationType(v *string) *BackendService {
+	if o.LocationType = v; o.LocationType == nil {
+		o.nullFields = append(o.nullFields, "LocationType")
+	}
+	return o
+}
+
+// SetScheme sets the scheme
+func (o *BackendService) SetScheme(v *string) *BackendService {
+	if o.Scheme = v; o.Scheme == nil {
+		o.nullFields = append(o.nullFields, "Scheme")
 	}
 	return o
 }

--- a/service/ocean/providers/aws/ocean.go
+++ b/service/ocean/providers/aws/ocean.go
@@ -577,6 +577,7 @@ func (o *LaunchSpecification) SetLoadBalancers(v []*LoadBalancer) *LaunchSpecifi
 	}
 	return o
 }
+
 // endregion
 
 // region LoadBalancer
@@ -600,6 +601,7 @@ func (o *LoadBalancer) SetType(v *string) *LoadBalancer {
 	}
 	return o
 }
+
 // endregion
 
 // region IAMInstanceProfile


### PR DESCRIPTION
[src] adding managedActions and deploymentPreferences to beanstalk
[src] adding loadBalancers and associatePublicIpAddress to Ocean
[src] added spotinstAccountID to domains
[src] added dockerswarm
[src] azure userdata, gcp backend svcs refactor
[src] added integrations for azure, addl fields for gcp, aws