### PR TITLE
Update ResourceSuggestion API call

### DIFF
--- a/service/ocean/providers/aws/right_sizing.go
+++ b/service/ocean/providers/aws/right_sizing.go
@@ -23,7 +23,8 @@ type ResourceSuggestion struct {
 
 // ListResourceSuggestionsInput represents the input of `ListResourceSuggestions` function.
 type ListResourceSuggestionsInput struct {
-	OceanID *string `json:"oceanId,omitempty"`
+	OceanID   *string `json:"oceanId,omitempty"`
+	Namespace *string `json:"namespace,omitempty"`
 }
 
 // ListResourceSuggestionsOutput represents the output of `ListResourceSuggestions` function.
@@ -74,6 +75,12 @@ func (s *ServiceOp) ListResourceSuggestions(ctx context.Context, input *ListReso
 	}
 
 	r := client.NewRequest(http.MethodGet, path)
+
+	if input.Namespace != nil {
+		r.Params.Set("namespace", *input.Namespace)
+	}
+	r.Obj = input
+
 	resp, err := client.RequireOK(s.Client.Do(ctx, r))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add Namespace query param to `ResourceSuggestionInput` object since API require `Namespace` as a mandatory field