### PR TITLE
feat(mcs): Add ebs cost field.

### DIFF
--- a/service/mcs/mcs.go
+++ b/service/mcs/mcs.go
@@ -26,6 +26,7 @@ type ClusterCost struct {
 	Deployments        []*Deployment `json:"deployments,omitempty"`
 	TotalCost          *float64      `json:"totalCost,omitempty"`
 	TotalComputeCost   *float64      `json:"totalComputeCost,omitempty"`
+	TotalEbsCost       *float64      `json:"totalEbsCost,omitempty"`
 	TotalStorageCost   *float64      `json:"totalStorageCost,omitempty"`
 	UnusedStorageCost  *float64      `json:"unusedStorageCost,omitempty"`
 	StandAlonePodsCost *float64      `json:"standAlonePodsCost,omitempty"`
@@ -37,6 +38,7 @@ type Namespace struct {
 	Namespace          *string           `json:"namespace,omitempty"`
 	Cost               *float64          `json:"cost,omitempty"`
 	ComputeCost        *float64          `json:"computeCost,omitempty"`
+	EbsCost            *float64          `json:"ebsCost,omitempty"`
 	StorageCost        *float64          `json:"storageCost,omitempty"`
 	Deployments        []*Resource       `json:"deployments,omitempty"`
 	StatefulSets       []*Resource       `json:"statefulSets,omitempty"`
@@ -63,6 +65,7 @@ type Resource struct {
 	Namespace   *string           `json:"namespace,omitempty"`
 	Cost        *float64          `json:"cost,omitempty"`
 	ComputeCost *float64          `json:"computeCost,omitempty"`
+	EbsCost     *float64          `json:"ebsCost,omitempty"`
 	StorageCost *float64          `json:"storageCost,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/service/mcs/mcs.go
+++ b/service/mcs/mcs.go
@@ -26,7 +26,7 @@ type ClusterCost struct {
 	Deployments        []*Deployment `json:"deployments,omitempty"`
 	TotalCost          *float64      `json:"totalCost,omitempty"`
 	TotalComputeCost   *float64      `json:"totalComputeCost,omitempty"`
-	TotalEbsCost       *float64      `json:"totalEbsCost,omitempty"`
+	TotalEBSCost       *float64      `json:"totalEbsCost,omitempty"`
 	TotalStorageCost   *float64      `json:"totalStorageCost,omitempty"`
 	UnusedStorageCost  *float64      `json:"unusedStorageCost,omitempty"`
 	StandAlonePodsCost *float64      `json:"standAlonePodsCost,omitempty"`
@@ -38,7 +38,7 @@ type Namespace struct {
 	Namespace          *string           `json:"namespace,omitempty"`
 	Cost               *float64          `json:"cost,omitempty"`
 	ComputeCost        *float64          `json:"computeCost,omitempty"`
-	EbsCost            *float64          `json:"ebsCost,omitempty"`
+	EBSCost            *float64          `json:"ebsCost,omitempty"`
 	StorageCost        *float64          `json:"storageCost,omitempty"`
 	Deployments        []*Resource       `json:"deployments,omitempty"`
 	StatefulSets       []*Resource       `json:"statefulSets,omitempty"`
@@ -65,7 +65,7 @@ type Resource struct {
 	Namespace   *string           `json:"namespace,omitempty"`
 	Cost        *float64          `json:"cost,omitempty"`
 	ComputeCost *float64          `json:"computeCost,omitempty"`
-	EbsCost     *float64          `json:"ebsCost,omitempty"`
+	EBSCost     *float64          `json:"ebsCost,omitempty"`
 	StorageCost *float64          `json:"storageCost,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`


### PR DESCRIPTION
 Hi, I've added the `ebsCost` field and the `totalEbsCost` field because they don't exist in SDK even though [the API of Spotinst](https://docs.spot.io/api/#operation/oceanAwsClusterCosts) is providing these fields. I hope It would be helpful :), or If I missed something please let me know. 