### PR TITLE
Add support for getting managed instance status

### DIFF
--- a/service/managedinstance/providers/aws/aws.go
+++ b/service/managedinstance/providers/aws/aws.go
@@ -311,12 +311,12 @@ type StatusManagedInstanceInput struct {
 
 type StatusManagedInstanceOutput struct {
 	ID           *string    `json:"id,omitempty"`
-	ImageId      *string    `json:"imageId,omitempty"`
-	InstanceId   *string    `json:"instanceId,omitempty"`
+	ImageID      *string    `json:"imageId,omitempty"`
+	InstanceID   *string    `json:"instanceId,omitempty"`
 	InstanceType *string    `json:"instanceType,omitempty"`
 	Name         *string    `json:"name,omitempty"`
-	PrivateIp    *string    `json:"privateIp,omitempty"`
-	PublicIp     *string    `json:"publicIp,omitempty"`
+	PrivateIP    *string    `json:"privateIp,omitempty"`
+	PublicIP     *string    `json:"publicIp,omitempty"`
 	Status       *string    `json:"status,omitempty"`
 	CreatedAt    *time.Time `json:"createdAt,omitempty"`
 	LaunchedAt   *time.Time `json:"launchedAt,omitempty"`

--- a/service/managedinstance/providers/aws/service.go
+++ b/service/managedinstance/providers/aws/service.go
@@ -17,6 +17,7 @@ type Service interface {
 	Read(context.Context, *ReadManagedInstanceInput) (*ReadManagedInstanceOutput, error)
 	Update(context.Context, *UpdateManagedInstanceInput) (*UpdateManagedInstanceOutput, error)
 	Delete(context.Context, *DeleteManagedInstanceInput) (*DeleteManagedInstanceOutput, error)
+	Status(context.Context, *StatusManagedInstanceInput) (*StatusManagedInstanceOutput, error)
 }
 
 type ServiceOp struct {


### PR DESCRIPTION
We are starting to use the spotinst-sdk-go for one of our projects and we needed some additional functionality for Managed Instances (currently, only the basic List, Read, Update, Delete functions are implemented).

This PR adds support for the Managed Instance Status API call which returns additional information from the cloud provider.

I tested it locally and it works as expected. There were no existing tests for this provider, so I haven't written a test for the new function.