### PR TITLE
feat(ocean/aws): add missing fields to ResourceSuggestion type

### DIFF
--- a/service/ocean/providers/aws/right_sizing.go
+++ b/service/ocean/providers/aws/right_sizing.go
@@ -13,10 +13,23 @@ import (
 
 // ResourceSuggestion represents a single resource suggestion.
 type ResourceSuggestion struct {
-	DeploymentName  *string  `json:"deploymentName,omitempty"`
-	Namespace       *string  `json:"namespace,omitempty"`
-	SuggestedCPU    *float64 `json:"suggestedCPU,omitempty"`
-	RequestedCPU    *float64 `json:"requestedCPU,omitempty"`
+	ResourceName    *string                        `json:"resourceName,omitempty"`
+	ResourceType    *string                        `json:"resourceType,omitempty"`
+	DeploymentName  *string                        `json:"deploymentName,omitempty"`
+	Namespace       *string                        `json:"namespace,omitempty"`
+	SuggestedCPU    *float64                       `json:"suggestedCPU,omitempty"`
+	RequestedCPU    *float64                       `json:"requestedCPU,omitempty"`
+	SuggestedMemory *float64                       `json:"suggestedMemory,omitempty"`
+	RequestedMemory *float64                       `json:"requestedMemory,omitempty"`
+	Containers      []*ContainerResourceSuggestion `json:"containers,omitempty"`
+}
+
+// ContainerResourceSuggestion represents a resource suggestion for a
+// single container.
+type ContainerResourceSuggestion struct {
+	Name            *string  `json:"name,omitempty"`
+	SuggestedCPU    *float64 `json:"suggestedCpu,omitempty"`
+	RequestedCPU    *float64 `json:"requestedCpu,omitempty"`
 	SuggestedMemory *float64 `json:"suggestedMemory,omitempty"`
 	RequestedMemory *float64 `json:"requestedMemory,omitempty"`
 }


### PR DESCRIPTION
The API also exposes the fields `resourceType` and `resourceName` but these are currently not part of the `ResourceSuggestion` type.

This makes resource suggestions for DaemonSets and StatefulSets not very useful as the information about the resource type and name are missing.

This change adds the missing fields `ResourceName` and `ResourceType` and, while we're at, also adds the missing `Containers` field.