### PR TITLE
Add support for managed instance costs

### DIFF
--- a/service/managedinstance/providers/aws/aws.go
+++ b/service/managedinstance/providers/aws/aws.go
@@ -342,6 +342,26 @@ type StatusManagedInstanceOutput struct {
 	LaunchedAt   *time.Time `json:"launchedAt,omitempty"`
 }
 
+type CostsManagedInstanceInput struct {
+	ManagedInstanceID *string `json:"managedInstanceId,omitempty"`
+}
+
+type CostsManagedInstanceOutput struct {
+	Costs   *Costs     `json:"costs"`
+	Running *UnitValue `json:"running"`
+	Savings *UnitValue `json:"savings"`
+}
+
+type Costs struct {
+	Actual    *float32 `json:"actual,omitempty"`
+	Potential *float32 `json:"potential,omitempty"`
+}
+
+type UnitValue struct {
+	Unit  *string  `json:"unit,omitempty"`
+	Value *float32 `json:"value,omitempty"`
+}
+
 func managedInstancesFromHttpResponse(resp *http.Response) ([]*ManagedInstance, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -531,6 +551,43 @@ func (s *ServiceOp) Status(ctx context.Context, input *StatusManagedInstanceInpu
 	}
 
 	output := new(StatusManagedInstanceOutput)
+	if err := json.Unmarshal(rw.Response.Items[0], output); err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func (s *ServiceOp) Costs(ctx context.Context, input *CostsManagedInstanceInput) (*CostsManagedInstanceOutput, error) {
+	path, err := uritemplates.Expand("/aws/ec2/managedInstance/{managedInstanceId}/costs", uritemplates.Values{
+		"managedInstanceId": spotinst.StringValue(input.ManagedInstanceID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r := client.NewRequest(http.MethodGet, path)
+	resp, err := client.RequireOK(s.Client.Do(ctx, r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var rw client.Response
+	if err := json.Unmarshal(body, &rw); err != nil {
+		return nil, err
+	}
+
+	if len(rw.Response.Items) == 0 {
+		return &CostsManagedInstanceOutput{}, nil
+	}
+
+	output := new(CostsManagedInstanceOutput)
 	if err := json.Unmarshal(rw.Response.Items[0], output); err != nil {
 		return nil, err
 	}

--- a/service/managedinstance/providers/aws/service.go
+++ b/service/managedinstance/providers/aws/service.go
@@ -18,6 +18,7 @@ type Service interface {
 	Update(context.Context, *UpdateManagedInstanceInput) (*UpdateManagedInstanceOutput, error)
 	Delete(context.Context, *DeleteManagedInstanceInput) (*DeleteManagedInstanceOutput, error)
 	Status(context.Context, *StatusManagedInstanceInput) (*StatusManagedInstanceOutput, error)
+	Costs(context.Context, *CostsManagedInstanceInput) (*CostsManagedInstanceOutput, error)
 }
 
 type ServiceOp struct {


### PR DESCRIPTION
This PR adds support for the Managed Instance Costs API call which returns cost information from the cloud provider.

The output looks something like this:
```json
{
    "costs": {
        "actual": 0.0031,
        "potential": 0.0094
    },
    "running": {
        "unit": "hours",
        "value": 1
    },
    "savings": {
        "unit": "percentage",
        "value": 67.0213
    }
}
```