### PR TITLE
add missing gke fields

### DIFF
--- a/service/ocean/providers/gcp/launchspec.go
+++ b/service/ocean/providers/gcp/launchspec.go
@@ -578,3 +578,29 @@ func (o *LaunchSpecStrategy) SetPreemptiblePercentage(v *int) *LaunchSpecStrateg
 }
 
 //endregion
+
+
+// region ShieldedInstanceConfig
+
+func (o ShieldedInstanceConfig) MarshalJSON() ([]byte, error) {
+	type noMethod ShieldedInstanceConfig
+	raw := noMethod(o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+func (o *ShieldedInstanceConfig) SetEnableIntegrityMonitoring(v *bool) *ShieldedInstanceConfig {
+	if o.EnableIntegrityMonitoring = v; o.EnableIntegrityMonitoring == nil {
+		o.nullFields = append(o.nullFields, "EnableIntegrityMonitoring")
+	}
+	return o
+}
+
+func (o *ShieldedInstanceConfig) SetEnableSecureBoot(v *bool) *ShieldedInstanceConfig {
+	if o.EnableSecureBoot = v; o.EnableSecureBoot == nil {
+		o.nullFields = append(o.nullFields, "EnableSecureBoot")
+	}
+	return o
+}
+
+//endregion
+

--- a/service/ocean/providers/gcp/launchspec.go
+++ b/service/ocean/providers/gcp/launchspec.go
@@ -13,15 +13,20 @@ import (
 )
 
 type LaunchSpec struct {
-	ID                *string             `json:"id,omitempty"`
-	OceanID           *string             `json:"oceanId,omitempty"`
-	SourceImage       *string             `json:"sourceImage,omitempty"`
-	Metadata          []*Metadata         `json:"metadata,omitempty"`
-	Labels            []*Label            `json:"labels,omitempty"`
-	Taints            []*Taint            `json:"taints,omitempty"`
-	AutoScale         *AutoScale          `json:"autoScale,omitempty"`
-	RestrictScaleDown *bool               `json:"restrictScaleDown,omitempty"`
-	Strategy          *LaunchSpecStrategy `json:"strategy,omitempty"`
+	ID                 *string             `json:"id,omitempty"`
+	Name               *string             `json:"name,omitempty"`
+	OceanID            *string             `json:"oceanId,omitempty"`
+	SourceImage        *string             `json:"sourceImage,omitempty"`
+	Metadata           []*Metadata         `json:"metadata,omitempty"`
+	Labels             []*Label            `json:"labels,omitempty"`
+	Taints             []*Taint            `json:"taints,omitempty"`
+	AutoScale          *AutoScale          `json:"autoScale,omitempty"`
+	RestrictScaleDown  *bool               `json:"restrictScaleDown,omitempty"`
+	Tags               []*Tag              `json:"tags,omitempty"`
+	Strategy           *LaunchSpecStrategy `json:"strategy,omitempty"`
+	IPForwarding       *bool               `json:"ipForwarding,omitempty"`
+	RootVolumeSizeInGB *int                `json:"rootVolumeSizeInGb,omitempty"`
+	ServiceAccount     *string             `json:"serviceAccount,omitempty"`
 
 	// forceSendFields is a list of field names (e.g. "Keys") to
 	// unconditionally include in API requests. By default, fields with

--- a/service/ocean/providers/gcp/launchspec.go
+++ b/service/ocean/providers/gcp/launchspec.go
@@ -27,8 +27,7 @@ type LaunchSpec struct {
 	RootVolumeSizeInGB     *int                    `json:"rootVolumeSizeInGb,omitempty"`
 	RootVolumeType         *string                 `json:"rootVolumeType,omitempty"`
 	ShieldedInstanceConfig *ShieldedInstanceConfig `json:"shieldedInstanceConfig,omitempty"`
-
-	ServiceAccount *string `json:"serviceAccount,omitempty"`
+	ServiceAccount         *string                 `json:"serviceAccount,omitempty"`
 
 	// forceSendFields is a list of field names (e.g. "Keys") to
 	// unconditionally include in API requests. By default, fields with
@@ -579,7 +578,6 @@ func (o *LaunchSpecStrategy) SetPreemptiblePercentage(v *int) *LaunchSpecStrateg
 
 //endregion
 
-
 // region ShieldedInstanceConfig
 
 func (o ShieldedInstanceConfig) MarshalJSON() ([]byte, error) {
@@ -603,4 +601,3 @@ func (o *ShieldedInstanceConfig) SetEnableSecureBoot(v *bool) *ShieldedInstanceC
 }
 
 //endregion
-

--- a/service/ocean/providers/gcp/launchspec.go
+++ b/service/ocean/providers/gcp/launchspec.go
@@ -25,6 +25,7 @@ type LaunchSpec struct {
 	Tags               []*Tag              `json:"tags,omitempty"`
 	Strategy           *LaunchSpecStrategy `json:"strategy,omitempty"`
 	RootVolumeSizeInGB *int                `json:"rootVolumeSizeInGb,omitempty"`
+	RootVolumeType     *string             `json:"rootVolumeType,omitempty"`
 	ServiceAccount     *string             `json:"serviceAccount,omitempty"`
 
 	// forceSendFields is a list of field names (e.g. "Keys") to

--- a/service/ocean/providers/gcp/launchspec.go
+++ b/service/ocean/providers/gcp/launchspec.go
@@ -13,20 +13,22 @@ import (
 )
 
 type LaunchSpec struct {
-	ID                 *string             `json:"id,omitempty"`
-	Name               *string             `json:"name,omitempty"`
-	OceanID            *string             `json:"oceanId,omitempty"`
-	SourceImage        *string             `json:"sourceImage,omitempty"`
-	Metadata           []*Metadata         `json:"metadata,omitempty"`
-	Labels             []*Label            `json:"labels,omitempty"`
-	Taints             []*Taint            `json:"taints,omitempty"`
-	AutoScale          *AutoScale          `json:"autoScale,omitempty"`
-	RestrictScaleDown  *bool               `json:"restrictScaleDown,omitempty"`
-	Tags               []*Tag              `json:"tags,omitempty"`
-	Strategy           *LaunchSpecStrategy `json:"strategy,omitempty"`
-	RootVolumeSizeInGB *int                `json:"rootVolumeSizeInGb,omitempty"`
-	RootVolumeType     *string             `json:"rootVolumeType,omitempty"`
-	ServiceAccount     *string             `json:"serviceAccount,omitempty"`
+	ID                     *string                 `json:"id,omitempty"`
+	Name                   *string                 `json:"name,omitempty"`
+	OceanID                *string                 `json:"oceanId,omitempty"`
+	SourceImage            *string                 `json:"sourceImage,omitempty"`
+	Metadata               []*Metadata             `json:"metadata,omitempty"`
+	Labels                 []*Label                `json:"labels,omitempty"`
+	Taints                 []*Taint                `json:"taints,omitempty"`
+	AutoScale              *AutoScale              `json:"autoScale,omitempty"`
+	RestrictScaleDown      *bool                   `json:"restrictScaleDown,omitempty"`
+	Tags                   []*Tag                  `json:"tags,omitempty"`
+	Strategy               *LaunchSpecStrategy     `json:"strategy,omitempty"`
+	RootVolumeSizeInGB     *int                    `json:"rootVolumeSizeInGb,omitempty"`
+	RootVolumeType         *string                 `json:"rootVolumeType,omitempty"`
+	ShieldedInstanceConfig *ShieldedInstanceConfig `json:"shieldedInstanceConfig,omitempty"`
+
+	ServiceAccount *string `json:"serviceAccount,omitempty"`
 
 	// forceSendFields is a list of field names (e.g. "Keys") to
 	// unconditionally include in API requests. By default, fields with
@@ -81,6 +83,14 @@ type AutoScaleHeadroom struct {
 
 type LaunchSpecStrategy struct {
 	PreemptiblePercentage *int `json:"preemptiblePercentage,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+type ShieldedInstanceConfig struct {
+	EnableSecureBoot          *bool `json:"enableSecureBoot,omitempty"`
+	EnableIntegrityMonitoring *bool `json:"enableIntegrityMonitoring,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -335,6 +345,13 @@ func (o *LaunchSpec) SetOceanId(v *string) *LaunchSpec {
 	return o
 }
 
+func (o *LaunchSpec) SetName(v *string) *LaunchSpec {
+	if o.Name = v; o.Name == nil {
+		o.nullFields = append(o.nullFields, "Name")
+	}
+	return o
+}
+
 func (o *LaunchSpec) SetSourceImage(v *string) *LaunchSpec {
 	if o.SourceImage = v; o.SourceImage == nil {
 		o.nullFields = append(o.nullFields, "SourceImage")
@@ -380,6 +397,41 @@ func (o *LaunchSpec) SetRestrictScaleDown(v *bool) *LaunchSpec {
 func (o *LaunchSpec) SetStrategy(v *LaunchSpecStrategy) *LaunchSpec {
 	if o.Strategy = v; o.Strategy == nil {
 		o.nullFields = append(o.nullFields, "Strategy")
+	}
+	return o
+}
+
+func (o *LaunchSpec) SetRootVolumeSizeInGB(v *int) *LaunchSpec {
+	if o.RootVolumeSizeInGB = v; o.RootVolumeSizeInGB == nil {
+		o.nullFields = append(o.nullFields, "RootVolumeSizeInGB")
+	}
+	return o
+}
+
+func (o *LaunchSpec) SetRootVolumeType(v *string) *LaunchSpec {
+	if o.RootVolumeType = v; o.RootVolumeType == nil {
+		o.nullFields = append(o.nullFields, "RootVolumeType")
+	}
+	return o
+}
+
+func (o *LaunchSpec) SetServiceAccount(v *string) *LaunchSpec {
+	if o.ServiceAccount = v; o.ServiceAccount == nil {
+		o.nullFields = append(o.nullFields, "ServiceAccount")
+	}
+	return o
+}
+
+func (o *LaunchSpec) SetTags(v []*Tag) *LaunchSpec {
+	if o.Tags = v; o.Tags == nil {
+		o.nullFields = append(o.nullFields, "Tags")
+	}
+	return o
+}
+
+func (o *LaunchSpec) SetShieldedInstanceConfig(v *ShieldedInstanceConfig) *LaunchSpec {
+	if o.ShieldedInstanceConfig = v; o.ShieldedInstanceConfig == nil {
+		o.nullFields = append(o.nullFields, "ShieldedInstanceConfig")
 	}
 	return o
 }

--- a/service/ocean/providers/gcp/launchspec.go
+++ b/service/ocean/providers/gcp/launchspec.go
@@ -24,7 +24,6 @@ type LaunchSpec struct {
 	RestrictScaleDown  *bool               `json:"restrictScaleDown,omitempty"`
 	Tags               []*Tag              `json:"tags,omitempty"`
 	Strategy           *LaunchSpecStrategy `json:"strategy,omitempty"`
-	IPForwarding       *bool               `json:"ipForwarding,omitempty"`
 	RootVolumeSizeInGB *int                `json:"rootVolumeSizeInGb,omitempty"`
 	ServiceAccount     *string             `json:"serviceAccount,omitempty"`
 


### PR DESCRIPTION
Add missing fields defined in the ocean gke launch specification. 

These values seem to be supported by the spot API as documented 
https://docs.spot.io/api/#operation/OceanGKELaunchSpecCreate

Potential fix for #126 