### PR TITLE
Adding Batch Min Healthy Percentage field

### DIFF
--- a/service/ocean/providers/aws/cluster.go
+++ b/service/ocean/providers/aws/cluster.go
@@ -293,6 +293,7 @@ type RollSpec struct {
 	Comment                      *string  `json:"comment,omitempty"`
 	Status                       *string  `json:"status,omitempty"`
 	BatchSizePercentage          *int     `json:"batchSizePercentage,omitempty"`
+	BatchMinHealthyPercentage    *int     `json:"batchMinHealthyPercentage,omitempty"`
 	DisableLaunchSpecAutoScaling *bool    `json:"disableLaunchSpecAutoScaling,omitempty"`
 	LaunchSpecIDs                []string `json:"launchSpecIds,omitempty"`
 	InstanceIDs                  []string `json:"instanceIds,omitempty"`
@@ -1510,6 +1511,13 @@ func (o *RollSpec) SetStatus(v *string) *RollSpec {
 func (o *RollSpec) SetBatchSizePercentage(v *int) *RollSpec {
 	if o.BatchSizePercentage = v; o.BatchSizePercentage == nil {
 		o.nullFields = append(o.nullFields, "BatchSizePercentage")
+	}
+	return o
+}
+
+func (o *RollSpec) SetBatchMinHealthyPercentage(v *int) *RollSpec {
+	if o.BatchMinHealthyPercentage = v; o.BatchMinHealthyPercentage == nil {
+		o.nullFields = append(o.nullFields, "BatchMinHealthyPercentage")
 	}
 	return o
 }

--- a/service/ocean/providers/aws/cluster_ecs.go
+++ b/service/ocean/providers/aws/cluster_ecs.go
@@ -222,11 +222,12 @@ type ECSRollClusterOutput struct {
 }
 
 type ECSRoll struct {
-	ClusterID           *string  `json:"clusterId,omitempty"`
-	Comment             *string  `json:"comment,omitempty"`
-	BatchSizePercentage *int     `json:"batchSizePercentage,omitempty"`
-	LaunchSpecIDs       []string `json:"launchSpecIds,omitempty"`
-	InstanceIDs         []string `json:"instanceIds,omitempty"`
+	ClusterID                 *string  `json:"clusterId,omitempty"`
+	Comment                   *string  `json:"comment,omitempty"`
+	BatchSizePercentage       *int     `json:"batchSizePercentage,omitempty"`
+	BatchMinHealthyPercentage *int     `json:"batchMinHealthyPercentage,omitempty"`
+	LaunchSpecIDs             []string `json:"launchSpecIds,omitempty"`
+	InstanceIDs               []string `json:"instanceIds,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1041,6 +1042,13 @@ func (o *ECSRoll) SetComment(v *string) *ECSRoll {
 func (o *ECSRoll) SetBatchSizePercentage(v *int) *ECSRoll {
 	if o.BatchSizePercentage = v; o.BatchSizePercentage == nil {
 		o.nullFields = append(o.nullFields, "BatchSizePercentage")
+	}
+	return o
+}
+
+func (o *ECSRoll) SetBatchMinHealthyPercentage(v *int) *ECSRoll {
+	if o.BatchMinHealthyPercentage = v; o.BatchMinHealthyPercentage == nil {
+		o.nullFields = append(o.nullFields, "BatchMinHealthyPercentage")
 	}
 	return o
 }

--- a/service/ocean/providers/gcp/cluster.go
+++ b/service/ocean/providers/gcp/cluster.go
@@ -267,11 +267,12 @@ type DeleteClusterInput struct {
 type DeleteClusterOutput struct{}
 
 type RollSpec struct {
-	ClusterID           *string  `json:"clusterId,omitempty"`
-	Comment             *string  `json:"comment,omitempty"`
-	BatchSizePercentage *int     `json:"batchSizePercentage,omitempty"`
-	LaunchSpecIDs       []string `json:"launchSpecIds,omitempty"`
-	InstanceNames       []string `json:"instanceNames,omitempty"`
+	ClusterID                 *string  `json:"clusterId,omitempty"`
+	Comment                   *string  `json:"comment,omitempty"`
+	BatchSizePercentage       *int     `json:"batchSizePercentage,omitempty"`
+	BatchMinHealthyPercentage *int     `json:"batchMinHealthyPercentage,omitempty"`
+	LaunchSpecIDs             []string `json:"launchSpecIds,omitempty"`
+	InstanceNames             []string `json:"instanceNames,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1337,6 +1338,13 @@ func (o *RollSpec) SetComment(v *string) *RollSpec {
 func (o *RollSpec) SetBatchSizePercentage(v *int) *RollSpec {
 	if o.BatchSizePercentage = v; o.BatchSizePercentage == nil {
 		o.nullFields = append(o.nullFields, "BatchSizePercentage")
+	}
+	return o
+}
+
+func (o *RollSpec) SetBatchMinHealthyPercentage(v *int) *RollSpec {
+	if o.BatchMinHealthyPercentage = v; o.BatchMinHealthyPercentage == nil {
+		o.nullFields = append(o.nullFields, "BatchMinHealthyPercentage")
 	}
 	return o
 }


### PR DESCRIPTION
Adding the field to ocean aws, ocean ecs and ocean gke import.
Ocean aws documentation - https://docs.spot.io/api/#operation/oceanAwsRollInit
Ocean ecs documentation - https://docs.spot.io/api/#operation/oceanEcsRollInit
Ocean gke import documentation - https://docs.spot.io/api/#operation/oceanGkeRollInit