### PR TITLE
Add GetAggregatedCosts() to AWS ocean clusters

### DIFF
--- a/service/ocean/providers/aws/service.go
+++ b/service/ocean/providers/aws/service.go
@@ -35,6 +35,8 @@ type serviceKubernetes interface {
 	DetachClusterInstances(context.Context, *DetachClusterInstancesInput) (*DetachClusterInstancesOutput, error)
 
 	GetLogEvents(context.Context, *GetLogEventsInput) (*GetLogEventsOutput, error)
+	
+	GetAggregatedCosts(context.Context, *GetAggregatedCostsInput) (*GetAggregatedCostsOutput, error)
 
 	ListRolls(context.Context, *ListRollsInput) (*ListRollsOutput, error)
 	CreateRoll(context.Context, *CreateRollInput) (*CreateRollOutput, error)


### PR DESCRIPTION
# Checklist:
- [ ] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
