### PR TITLE
Feat: add support for spot_percentage in Ocean ECS Launch Spec

### DIFF
--- a/service/ocean/providers/aws/launchspec_ecs.go
+++ b/service/ocean/providers/aws/launchspec_ecs.go
@@ -27,6 +27,7 @@ type ECSLaunchSpec struct {
 	Tags                 []*Tag                   `json:"tags,omitempty"`
 	InstanceTypes        []string                 `json:"instanceTypes,omitempty"`
 	PreferredSpotTypes   []string                 `json:"preferredSpotTypes,omitempty"`
+	Strategy             *ECSLaunchSpecStrategy   `json:"strategy,omitempty"`
 	RestrictScaleDown    *bool                    `json:"restrictScaleDown,omitempty"`
 	SubnetIDs            []string                 `json:"subnetIds,omitempty"`
 	LaunchSpecScheduling *ECSLaunchSpecScheduling `json:"scheduling,omitempty"`
@@ -105,6 +106,13 @@ type ECSDynamicVolumeSize struct {
 	BaseSize            *int    `json:"baseSize,omitempty"`
 	SizePerResourceUnit *int    `json:"sizePerResourceUnit,omitempty"`
 	Resource            *string `json:"resource,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+type ECSLaunchSpecStrategy struct {
+	SpotPercentage *int `json:"spotPercentage,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -672,6 +680,23 @@ func (o *ECSDynamicVolumeSize) SetResource(v *string) *ECSDynamicVolumeSize {
 func (o *ECSDynamicVolumeSize) SetSizePerResourceUnit(v *int) *ECSDynamicVolumeSize {
 	if o.SizePerResourceUnit = v; o.SizePerResourceUnit == nil {
 		o.nullFields = append(o.nullFields, "SizePerResourceUnit")
+	}
+	return o
+}
+
+// endregion
+
+// region LaunchSpecStrategy
+
+func (o ECSLaunchSpecStrategy) MarshalJSON() ([]byte, error) {
+	type noMethod ECSLaunchSpecStrategy
+	raw := noMethod(o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+func (o *ECSLaunchSpecStrategy) SetSpotPercentage(v *int) *ECSLaunchSpecStrategy {
+	if o.SpotPercentage = v; o.SpotPercentage == nil {
+		o.nullFields = append(o.nullFields, "SpotPercentage")
 	}
 	return o
 }


### PR DESCRIPTION
Signed-off-by: Marino Borges <omarinoborges@gmail.com>

This PR provides support for `strategy.spotPercentage` in `spotinst_ocean_ecs_launch_spec` resource ([API docs](https://docs.spot.io/api/#operation/OceanECSLaunchSpecCreate:~:text=virtual%20node%20group.-,spotPercentage,-integer%20%5B%200%20..%20100))