### PR TITLE
Spotaut 13265 aws eg ocean tf set access to instance meta data tags

### DIFF
--- a/examples/service/elastigroup/providers/aws/create/main.go
+++ b/examples/service/elastigroup/providers/aws/create/main.go
@@ -60,6 +60,10 @@ func main() {
 					ImageID:          spotinst.String("ami-12345"),
 					Monitoring:       spotinst.Bool(false),
 					SecurityGroupIDs: []string{"sg-foo"},
+					MetadataOptions: &aws.MetadataOptions{
+						HTTPTokens:              spotinst.String("optional"),
+						HTTPPutResponseHopLimit: spotinst.Int(20),
+					},
 				},
 			},
 		},

--- a/service/ocean/providers/aws/launchspec.go
+++ b/service/ocean/providers/aws/launchspec.go
@@ -15,28 +15,29 @@ import (
 )
 
 type LaunchSpec struct {
-	ID                       *string               `json:"id,omitempty"`
-	Name                     *string               `json:"name,omitempty"`
-	OceanID                  *string               `json:"oceanId,omitempty"`
-	ImageID                  *string               `json:"imageId,omitempty"`
-	UserData                 *string               `json:"userData,omitempty"`
-	RootVolumeSize           *int                  `json:"rootVolumeSize,omitempty"`
-	SecurityGroupIDs         []string              `json:"securityGroupIds,omitempty"`
-	SubnetIDs                []string              `json:"subnetIds,omitempty"`
-	InstanceTypes            []string              `json:"instanceTypes,omitempty"`
-	PreferredSpotTypes       []string              `json:"preferredSpotTypes,omitempty"`
-	Strategy                 *LaunchSpecStrategy   `json:"strategy,omitempty"`
-	ResourceLimits           *ResourceLimits       `json:"resourceLimits,omitempty"`
-	IAMInstanceProfile       *IAMInstanceProfile   `json:"iamInstanceProfile,omitempty"`
-	AutoScale                *AutoScale            `json:"autoScale,omitempty"`
-	ElasticIPPool            *ElasticIPPool        `json:"elasticIpPool,omitempty"`
-	BlockDeviceMappings      []*BlockDeviceMapping `json:"blockDeviceMappings,omitempty"`
-	Labels                   []*Label              `json:"labels,omitempty"`
-	Taints                   []*Taint              `json:"taints,omitempty"`
-	Tags                     []*Tag                `json:"tags,omitempty"`
-	AssociatePublicIPAddress *bool                 `json:"associatePublicIpAddress,omitempty"`
-	RestrictScaleDown        *bool                 `json:"restrictScaleDown,omitempty"`
-	LaunchSpecScheduling     *LaunchSpecScheduling `json:"scheduling,omitempty"`
+	ID                       *string                            `json:"id,omitempty"`
+	Name                     *string                            `json:"name,omitempty"`
+	OceanID                  *string                            `json:"oceanId,omitempty"`
+	ImageID                  *string                            `json:"imageId,omitempty"`
+	UserData                 *string                            `json:"userData,omitempty"`
+	RootVolumeSize           *int                               `json:"rootVolumeSize,omitempty"`
+	SecurityGroupIDs         []string                           `json:"securityGroupIds,omitempty"`
+	SubnetIDs                []string                           `json:"subnetIds,omitempty"`
+	InstanceTypes            []string                           `json:"instanceTypes,omitempty"`
+	PreferredSpotTypes       []string                           `json:"preferredSpotTypes,omitempty"`
+	Strategy                 *LaunchSpecStrategy                `json:"strategy,omitempty"`
+	ResourceLimits           *ResourceLimits                    `json:"resourceLimits,omitempty"`
+	IAMInstanceProfile       *IAMInstanceProfile                `json:"iamInstanceProfile,omitempty"`
+	AutoScale                *AutoScale                         `json:"autoScale,omitempty"`
+	ElasticIPPool            *ElasticIPPool                     `json:"elasticIpPool,omitempty"`
+	BlockDeviceMappings      []*BlockDeviceMapping              `json:"blockDeviceMappings,omitempty"`
+	Labels                   []*Label                           `json:"labels,omitempty"`
+	Taints                   []*Taint                           `json:"taints,omitempty"`
+	Tags                     []*Tag                             `json:"tags,omitempty"`
+	AssociatePublicIPAddress *bool                              `json:"associatePublicIpAddress,omitempty"`
+	RestrictScaleDown        *bool                              `json:"restrictScaleDown,omitempty"`
+	LaunchSpecScheduling     *LaunchSpecScheduling              `json:"scheduling,omitempty"`
+	InstanceMetadataOptions  *LaunchspecInstanceMetadataOptions `json:"instanceMetadataOptions,omitempty"`
 
 	// Read-only fields.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
@@ -58,6 +59,44 @@ type LaunchSpec struct {
 	// This may be used to include null fields in Patch requests.
 	nullFields []string
 }
+
+// region InstanceMetadataOptions
+
+type LaunchspecInstanceMetadataOptions struct {
+	HTTPTokens              *string `json:"httpTokens,omitempty"`
+	HTTPPutResponseHopLimit *int    `json:"httpPutResponseHopLimit,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+func (o *LaunchspecInstanceMetadataOptions) SetHTTPTokens(v *string) *LaunchspecInstanceMetadataOptions {
+	if o.HTTPTokens = v; o.HTTPTokens == nil {
+		o.nullFields = append(o.nullFields, "HTTPTokens")
+	}
+	return o
+}
+
+func (o *LaunchspecInstanceMetadataOptions) SetHTTPPutResponseHopLimit(v *int) *LaunchspecInstanceMetadataOptions {
+	if o.HTTPPutResponseHopLimit = v; o.HTTPPutResponseHopLimit == nil {
+		o.nullFields = append(o.nullFields, "HTTPPutResponseHopLimit")
+	}
+	return o
+}
+
+func (o *LaunchSpec) SetLaunchspecInstanceMetadataOptions(v *LaunchspecInstanceMetadataOptions) *LaunchSpec {
+	if o.InstanceMetadataOptions = v; o.InstanceMetadataOptions == nil {
+		o.nullFields = append(o.nullFields, "InstanceMetadataOptions")
+	}
+	return o
+}
+func (o LaunchspecInstanceMetadataOptions) MarshalJSON() ([]byte, error) {
+	type noMethod LaunchspecInstanceMetadataOptions
+	raw := noMethod(o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+// endregion
 
 type ResourceLimits struct {
 	MaxInstanceCount *int `json:"maxInstanceCount,omitempty"`

--- a/service/ocean/providers/aws/launchspec_ecs.go
+++ b/service/ocean/providers/aws/launchspec_ecs.go
@@ -14,23 +14,24 @@ import (
 )
 
 type ECSLaunchSpec struct {
-	ID                   *string                  `json:"id,omitempty"`
-	Name                 *string                  `json:"name,omitempty"`
-	OceanID              *string                  `json:"oceanId,omitempty"`
-	ImageID              *string                  `json:"imageId,omitempty"`
-	UserData             *string                  `json:"userData,omitempty"`
-	SecurityGroupIDs     []string                 `json:"securityGroupIds,omitempty"`
-	AutoScale            *ECSAutoScale            `json:"autoScale,omitempty"`
-	IAMInstanceProfile   *ECSIAMInstanceProfile   `json:"iamInstanceProfile,omitempty"`
-	Attributes           []*ECSAttribute          `json:"attributes,omitempty"`
-	BlockDeviceMappings  []*ECSBlockDeviceMapping `json:"blockDeviceMappings,omitempty"`
-	Tags                 []*Tag                   `json:"tags,omitempty"`
-	InstanceTypes        []string                 `json:"instanceTypes,omitempty"`
-	PreferredSpotTypes   []string                 `json:"preferredSpotTypes,omitempty"`
-	Strategy             *ECSLaunchSpecStrategy   `json:"strategy,omitempty"`
-	RestrictScaleDown    *bool                    `json:"restrictScaleDown,omitempty"`
-	SubnetIDs            []string                 `json:"subnetIds,omitempty"`
-	LaunchSpecScheduling *ECSLaunchSpecScheduling `json:"scheduling,omitempty"`
+	ID                      *string                               `json:"id,omitempty"`
+	Name                    *string                               `json:"name,omitempty"`
+	OceanID                 *string                               `json:"oceanId,omitempty"`
+	ImageID                 *string                               `json:"imageId,omitempty"`
+	UserData                *string                               `json:"userData,omitempty"`
+	SecurityGroupIDs        []string                              `json:"securityGroupIds,omitempty"`
+	AutoScale               *ECSAutoScale                         `json:"autoScale,omitempty"`
+	IAMInstanceProfile      *ECSIAMInstanceProfile                `json:"iamInstanceProfile,omitempty"`
+	Attributes              []*ECSAttribute                       `json:"attributes,omitempty"`
+	BlockDeviceMappings     []*ECSBlockDeviceMapping              `json:"blockDeviceMappings,omitempty"`
+	Tags                    []*Tag                                `json:"tags,omitempty"`
+	InstanceTypes           []string                              `json:"instanceTypes,omitempty"`
+	PreferredSpotTypes      []string                              `json:"preferredSpotTypes,omitempty"`
+	Strategy                *ECSLaunchSpecStrategy                `json:"strategy,omitempty"`
+	RestrictScaleDown       *bool                                 `json:"restrictScaleDown,omitempty"`
+	SubnetIDs               []string                              `json:"subnetIds,omitempty"`
+	LaunchSpecScheduling    *ECSLaunchSpecScheduling              `json:"scheduling,omitempty"`
+	InstanceMetadataOptions *ECSLaunchspecInstanceMetadataOptions `json:"instanceMetadataOptions,omitempty"`
 
 	// Read-only fields.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
@@ -52,6 +53,44 @@ type ECSLaunchSpec struct {
 	// This may be used to include null fields in Patch requests.
 	nullFields []string
 }
+
+// region InstanceMetadataOptions
+
+type ECSLaunchspecInstanceMetadataOptions struct {
+	HTTPTokens              *string `json:"httpTokens,omitempty"`
+	HTTPPutResponseHopLimit *int    `json:"httpPutResponseHopLimit,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+func (o *ECSLaunchspecInstanceMetadataOptions) SetHTTPTokens(v *string) *ECSLaunchspecInstanceMetadataOptions {
+	if o.HTTPTokens = v; o.HTTPTokens == nil {
+		o.nullFields = append(o.nullFields, "HTTPTokens")
+	}
+	return o
+}
+
+func (o *ECSLaunchspecInstanceMetadataOptions) SetHTTPPutResponseHopLimit(v *int) *ECSLaunchspecInstanceMetadataOptions {
+	if o.HTTPPutResponseHopLimit = v; o.HTTPPutResponseHopLimit == nil {
+		o.nullFields = append(o.nullFields, "HTTPPutResponseHopLimit")
+	}
+	return o
+}
+
+func (o *ECSLaunchSpec) SetECSLaunchspecInstanceMetadataOptions(v *ECSLaunchspecInstanceMetadataOptions) *ECSLaunchSpec {
+	if o.InstanceMetadataOptions = v; o.InstanceMetadataOptions == nil {
+		o.nullFields = append(o.nullFields, "InstanceMetadataOptions")
+	}
+	return o
+}
+func (o ECSLaunchspecInstanceMetadataOptions) MarshalJSON() ([]byte, error) {
+	type noMethod ECSLaunchspecInstanceMetadataOptions
+	raw := noMethod(o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+// endregion
 
 type ECSAttribute struct {
 	Key   *string `json:"key,omitempty"`


### PR DESCRIPTION
Added support for instanceMetadataOptions in Ocean AWS and ECS VNG.

# Jira Ticket
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-13265

