### PR TITLE
BGD-2995 ForceDelete query param to DeleteCluster

### DIFF
--- a/examples/service/ocean/spark/cluster/delete/main.go
+++ b/examples/service/ocean/spark/cluster/delete/main.go
@@ -29,7 +29,8 @@ func main() {
 
 	// Delete an existing cluster.
 	_, err := svc.Spark().DeleteCluster(ctx, &spark.DeleteClusterInput{
-		ClusterID: spotinst.String("osc-12345"),
+		ClusterID:   spotinst.String("osc-12345"),
+		ForceDelete: spotinst.Bool(false),
 	})
 	if err != nil {
 		log.Fatalf("spotinst: failed to delete cluster: %v", err)

--- a/service/ocean/spark/cluster.go
+++ b/service/ocean/spark/cluster.go
@@ -155,7 +155,8 @@ type UpdateClusterRequest struct {
 type UpdateClusterOutput struct{}
 
 type DeleteClusterInput struct {
-	ClusterID *string `json:"clusterId,omitempty"`
+	ForceDelete *bool   `json:"-"`
+	ClusterID   *string `json:"clusterId,omitempty"`
 }
 
 type DeleteClusterOutput struct{}

--- a/service/ocean/spark/spark.go
+++ b/service/ocean/spark/spark.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+
 	"github.com/spotinst/spotinst-sdk-go/spotinst"
 	"github.com/spotinst/spotinst-sdk-go/spotinst/client"
 	"github.com/spotinst/spotinst-sdk-go/spotinst/util/uritemplates"
-	"io/ioutil"
-	"net/http"
 )
 
 // region Cluster
@@ -84,6 +86,10 @@ func (s *ServiceOp) DeleteCluster(ctx context.Context, input *DeleteClusterInput
 	}
 
 	r := client.NewRequest(http.MethodDelete, path)
+
+	if input.ForceDelete != nil {
+		r.Params.Set("forceDelete", strconv.FormatBool(spotinst.BoolValue(input.ForceDelete)))
+	}
 
 	resp, err := client.RequireOK(s.Client.Do(ctx, r))
 	if err != nil {


### PR DESCRIPTION
https://spotinst.atlassian.net/browse/BGD-2995

Motivation: 
supply wait-for-deletion query parameter in deletion call
block until the cluster goes away in deletion call
we need to

add support for the new forceDelete query parameter in the spotinst-sdk-go
supply this query parameter in the terraform provider delete cluster call
wait for the cluster to be deleted in the terraform provider
