### PR TITLE
Fixed deletion of "images" in ocean-aws-launchSpec.

### DIFF
--- a/service/ocean/providers/aws/launchspec_ecs.go
+++ b/service/ocean/providers/aws/launchspec_ecs.go
@@ -236,7 +236,7 @@ type ECSImages struct {
 
 func (o *ECSLaunchSpec) SetECSImages(v []*ECSImages) *ECSLaunchSpec {
 	if o.Images = v; o.Images == nil {
-		o.nullFields = append(o.nullFields, "ECSImages")
+		o.nullFields = append(o.nullFields, "Images")
 	}
 	return o
 }


### PR DESCRIPTION
Fixed deletion of "images" in ocean-aws-launchSpec.

# Jira Ticket
Ref: https://spotinst.atlassian.net/browse/SPOTAUT-17017