### PR TITLE
Add BGInstances access to RollStatus

### DIFF
--- a/service/elastigroup/providers/aws/aws.go
+++ b/service/elastigroup/providers/aws/aws.go
@@ -1094,6 +1094,27 @@ type DeploymentStatusInput struct {
 	RollID  *string `json:"id,omitempty"`
 }
 
+type RollStatusInput struct {
+	GroupID *string `json:"groupId,omitempty"`
+	RollID  *string `json:"id,omitempty"`
+}
+
+type BGInstance struct {
+	InstanceID *string `json:"instanceId,omitempty"`
+	Lifecycle  *string `json:"lifecycle,omitempty"`
+	BatchNum   *int    `json:"batchNum,omitempty"`
+	Status     *string `json:"status,omitempty"`
+}
+
+type BGInstances struct {
+	Blue  []*BGInstance `json:"blue,omitempty"`
+	Green []*BGInstance `json:"green,omitempty"`
+}
+
+type RollStatusOutput struct {
+	Instances []*BGInstances `json:"instances,omitempty"`
+}
+
 type Roll struct {
 	Status *string `json:"status,omitempty"`
 }
@@ -1222,13 +1243,44 @@ func deploymentStatusesFromJSON(in []byte) ([]*RollGroupStatus, error) {
 	}
 	return out, nil
 }
-
 func deploymentStatusFromHttpResponse(resp *http.Response) ([]*RollGroupStatus, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 	return deploymentStatusesFromJSON(body)
+}
+
+func rollStatusOutputFromJSON(in []byte) (*RollStatusOutput, error) {
+	b := new(RollStatusOutput)
+	if err := json.Unmarshal(in, b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func rollStatusFromJSON(in []byte) (*RollStatusOutput, error) {
+	var rw client.Response
+	if err := json.Unmarshal(in, &rw); err != nil {
+		return nil, err
+	}
+	if len(rw.Response.Items) == 0 {
+		return nil, nil
+	}
+	// Only 1 roll allowed at a time
+	rollStatusOutput, err := rollStatusOutputFromJSON(rw.Response.Items[0])
+	if err != nil {
+		return nil, err
+	}
+	return rollStatusOutput, nil
+}
+
+func rollStatusFromHttpResponse(resp *http.Response) (*RollStatusOutput, error) {
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return rollStatusFromJSON(body)
 }
 
 func groupFromJSON(in []byte) (*Group, error) {
@@ -1691,6 +1743,31 @@ func (s *ServiceOp) Roll(ctx context.Context, input *RollGroupInput) (*RollGroup
 	}
 
 	return &RollGroupOutput{deployments}, nil
+}
+
+func (s *ServiceOp) RollStatus(ctx context.Context, input *RollStatusInput) (*RollStatusOutput, error) {
+	path, err := uritemplates.Expand("/aws/ec2/group/{groupId}/roll/{rollId}/status", uritemplates.Values{
+		"groupId": spotinst.StringValue(input.GroupID),
+		"rollId":  spotinst.StringValue(input.RollID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r := client.NewRequest(http.MethodGet, path)
+
+	resp, err := client.RequireOK(s.Client.Do(ctx, r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	status, err := rollStatusFromHttpResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return status, nil
 }
 
 func (s *ServiceOp) RollECS(ctx context.Context, input *RollECSGroupInput) (*RollGroupOutput, error) {

--- a/service/elastigroup/providers/aws/service.go
+++ b/service/elastigroup/providers/aws/service.go
@@ -26,6 +26,7 @@ type Service interface {
 	StopDeployment(context.Context, *StopDeploymentInput) (*StopDeploymentOutput, error)
 
 	Roll(context.Context, *RollGroupInput) (*RollGroupOutput, error)
+	RollStatus(context.Context, *RollStatusInput) (*RollStatusOutput, error)
 	RollECS(context.Context, *RollECSGroupInput) (*RollGroupOutput, error)
 
 	GetInstanceHealthiness(context.Context, *GetInstanceHealthinessInput) (*GetInstanceHealthinessOutput, error)


### PR DESCRIPTION
Blue and Green Instance Metadata and Status from the RollStatus API should be exposed to the golang sdk layer

# Checklist:
- [ ] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [ ] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
