### PR TITLE
Added support for attach and detach loadBalancers to ocean aws k8s cluster in go-sdk

### DIFF
--- a/examples/service/ocean/providers/aws/attachLoadBalancer/main.go
+++ b/examples/service/ocean/providers/aws/attachLoadBalancer/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"github.com/spotinst/spotinst-sdk-go/service/ocean"
+	"github.com/spotinst/spotinst-sdk-go/service/ocean/providers/aws"
+	"github.com/spotinst/spotinst-sdk-go/spotinst"
+	"github.com/spotinst/spotinst-sdk-go/spotinst/session"
+	"log"
+)
+
+func main() {
+	// All clients require a Session. The Session provides the client with
+	// shared configuration such as account and credentials.
+	// A Session should be shared where possible to take advantage of
+	// configuration and credential caching. See the session package for
+	// more information.
+	sess := session.New()
+
+	// Create a new instance of the service's client with a Session.
+	// Optional spotinst.Config values can also be provided as variadic
+	// arguments to the New function. This option allows you to provide
+	// service specific configuration.
+	svc := ocean.New(sess)
+
+	// Create a new context.
+	ctx := context.Background()
+
+	// Attach LoadBalancer configuration.
+	_, err := svc.CloudProviderAWS().AttachLoadBalancer(ctx, &aws.AttachLoadbalancerInput{
+		LoadBalancers: []*aws.LoadBalancers{
+			&aws.LoadBalancers{
+				Name: spotinst.String("Test-LoadBalancer-Attach"),
+				Arn:  spotinst.String("arn:aws:"),
+				Type: spotinst.String("TARGET_GROUP"),
+			},
+		},
+		ID: spotinst.String("o-1234567"),
+	})
+	if err != nil {
+		log.Fatalf("spotinst: failed to attach Load Balancer to Ocean Cluster: %v", err)
+	}
+}

--- a/examples/service/ocean/providers/aws/detachLoadBalancer/main.go
+++ b/examples/service/ocean/providers/aws/detachLoadBalancer/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"github.com/spotinst/spotinst-sdk-go/service/ocean"
+	"github.com/spotinst/spotinst-sdk-go/service/ocean/providers/aws"
+	"github.com/spotinst/spotinst-sdk-go/spotinst"
+	"github.com/spotinst/spotinst-sdk-go/spotinst/session"
+	"log"
+)
+
+func main() {
+	// All clients require a Session. The Session provides the client with
+	// shared configuration such as account and credentials.
+	// A Session should be shared where possible to take advantage of
+	// configuration and credential caching. See the session package for
+	// more information.
+	sess := session.New()
+
+	// Create a new instance of the service's client with a Session.
+	// Optional spotinst.Config values can also be provided as variadic
+	// arguments to the New function. This option allows you to provide
+	// service specific configuration.
+	svc := ocean.New(sess)
+
+	// Create a new context.
+	ctx := context.Background()
+
+	// Detach LoadBalancer configuration.
+	_, err := svc.CloudProviderAWS().DetachLoadBalancer(ctx, &aws.DetachLoadbalancerInput{
+		LoadBalancers: []*aws.LoadBalancers{
+			&aws.LoadBalancers{
+				Name: spotinst.String("Test-LoadBalancer-Detach"),
+				Arn:  spotinst.String("arn:aws:"),
+				Type: spotinst.String("TARGET_GROUP"),
+			},
+		},
+		ID: spotinst.String("o-1234567"),
+	})
+	if err != nil {
+		log.Fatalf("spotinst: failed to detach Load Balancer from Ocean Cluster: %v", err)
+	}
+}

--- a/service/ocean/providers/aws/loadbalancer.go
+++ b/service/ocean/providers/aws/loadbalancer.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"context"
+	"github.com/spotinst/spotinst-sdk-go/spotinst"
+	"github.com/spotinst/spotinst-sdk-go/spotinst/client"
+	"github.com/spotinst/spotinst-sdk-go/spotinst/util/uritemplates"
+	"net/http"
+)
+
+type LoadBalancers struct {
+	Arn  *string `json:"arn,omitempty"`
+	Name *string `json:"name,omitempty"`
+	Type *string `json:"type,omitempty"`
+}
+
+type AttachLoadbalancerInput struct {
+	LoadBalancers []*LoadBalancers `json:"loadBalancers,omitempty"`
+	ID            *string          `json:"id,omitempty"`
+}
+
+type AttachLoadbalancerOutput struct{}
+
+type DetachLoadbalancerInput struct {
+	LoadBalancers []*LoadBalancers `json:"loadBalancers,omitempty"`
+	ID            *string          `json:"id,omitempty"`
+}
+
+type DetachLoadbalancerOutput struct{}
+
+func (s *ServiceOp) AttachLoadBalancer(ctx context.Context,
+	input *AttachLoadbalancerInput) (*AttachLoadbalancerOutput, error) {
+	path, err := uritemplates.Expand("/ocean/aws/k8s/cluster/{oceanClusterId}/loadBalancer/attach", uritemplates.Values{
+		"oceanClusterId": spotinst.StringValue(input.ID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	input.ID = nil
+
+	r := client.NewRequest(http.MethodPut, path)
+	r.Obj = input
+
+	resp, err := client.RequireOK(s.Client.Do(ctx, r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return &AttachLoadbalancerOutput{}, nil
+}
+
+func (s *ServiceOp) DetachLoadBalancer(ctx context.Context,
+	input *DetachLoadbalancerInput) (*DetachLoadbalancerOutput, error) {
+	path, err := uritemplates.Expand("/ocean/aws/k8s/cluster/{oceanClusterId}/loadBalancer/detach", uritemplates.Values{
+		"oceanClusterId": spotinst.StringValue(input.ID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	input.ID = nil
+
+	r := client.NewRequest(http.MethodPut, path)
+	r.Obj = input
+
+	resp, err := client.RequireOK(s.Client.Do(ctx, r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return &DetachLoadbalancerOutput{}, nil
+}

--- a/service/ocean/providers/aws/service.go
+++ b/service/ocean/providers/aws/service.go
@@ -52,6 +52,8 @@ type serviceKubernetes interface {
 	ListMigrations(context.Context, *ReadMigrationInput) (*ReadMigrationOutput, error)
 
 	MigrationStatus(context.Context, *ReadMigrationStatusInput) (*ReadMigrationStatusOutput, error)
+	AttachLoadBalancer(context.Context, *AttachLoadbalancerInput) (*AttachLoadbalancerOutput, error)
+	DetachLoadBalancer(context.Context, *DetachLoadbalancerInput) (*DetachLoadbalancerOutput, error)
 }
 
 type serviceECS interface {


### PR DESCRIPTION
Added support for attach and detach loadBalancers to ocean aws k8s cluster in go-sdk

https://spotinst.atlassian.net/browse/SPOTAUT-18601