### PR TITLE
Added support for `UtilizeCommitments` and `UtilizeReservedInstances` under strategy in ocean_aws_launchspec.

### DIFF
--- a/examples/service/ocean/providers/aws/launchSpec/create/main.go
+++ b/examples/service/ocean/providers/aws/launchSpec/create/main.go
@@ -35,6 +35,11 @@ func main() {
 			ImageID:          spotinst.String("ami-abcd123456"),
 			SecurityGroupIDs: []string{"sg-123456"},
 			SubnetIDs:        []string{"subnet-12345", "subnet-67890"},
+			Strategy: &aws.LaunchSpecStrategy{
+				DrainingTimeout:          spotinst.Int(500),
+				UtilizeCommitments:       spotinst.Bool(true),
+				UtilizeReservedInstances: spotinst.Bool(true),
+			},
 			InstanceTypesFilters: &aws.InstanceTypesFilters{
 				DiskTypes:             []string{"EBS", "SSD"},
 				MinVcpu:               spotinst.Int(2),

--- a/service/ocean/providers/aws/launchspec.go
+++ b/service/ocean/providers/aws/launchspec.go
@@ -221,8 +221,10 @@ type TagSelector struct {
 }
 
 type LaunchSpecStrategy struct {
-	SpotPercentage  *int `json:"spotPercentage,omitempty"`
-	DrainingTimeout *int `json:"drainingTimeout,omitempty"`
+	SpotPercentage           *int  `json:"spotPercentage,omitempty"`
+	DrainingTimeout          *int  `json:"drainingTimeout,omitempty"`
+	UtilizeCommitments       *bool `json:"utilizeCommitments,omitempty"`
+	UtilizeReservedInstances *bool `json:"utilizeReservedInstances,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1047,6 +1049,20 @@ func (o *LaunchSpecStrategy) SetSpotPercentage(v *int) *LaunchSpecStrategy {
 func (o *LaunchSpecStrategy) SetDrainingTimeout(v *int) *LaunchSpecStrategy {
 	if o.DrainingTimeout = v; o.DrainingTimeout == nil {
 		o.nullFields = append(o.nullFields, "DrainingTimeout")
+	}
+	return o
+}
+
+func (o *LaunchSpecStrategy) SetUtilizeCommitments(v *bool) *LaunchSpecStrategy {
+	if o.UtilizeCommitments = v; o.UtilizeCommitments == nil {
+		o.nullFields = append(o.nullFields, "UtilizeCommitments")
+	}
+	return o
+}
+
+func (o *LaunchSpecStrategy) SetUtilizeReservedInstances(v *bool) *LaunchSpecStrategy {
+	if o.UtilizeReservedInstances = v; o.UtilizeReservedInstances == nil {
+		o.nullFields = append(o.nullFields, "UtilizeReservedInstances")
 	}
 	return o
 }


### PR DESCRIPTION
Added support for `UtilizeCommitments` and `UtilizeReservedInstances` in ocean_aws_launchspec.

# Jira Ticket

Ref: https://spotinst.atlassian.net/browse/SPOTAUT-16900
