### PR TITLE
feat (ocean/spark): Added 'WorkspacesConfig' to 'Config'  [BGD-6259]

### DIFF
--- a/examples/service/ocean/spark/cluster/create/main.go
+++ b/examples/service/ocean/spark/cluster/create/main.go
@@ -76,6 +76,9 @@ func main() {
 						"spark-apps-extra-ns-2",
 					}),
 				},
+				Workspaces: &spark.WorkspacesConfig{
+					StorageClassOverride: spotinst.String("gp2"),
+				},
 			},
 		},
 	})

--- a/examples/service/ocean/spark/cluster/update/main.go
+++ b/examples/service/ocean/spark/cluster/update/main.go
@@ -75,6 +75,9 @@ func main() {
 						"spark-apps-extra-ns-2",
 					}),
 				},
+				Workspaces: &spark.WorkspacesConfig{
+					StorageClassOverride: spotinst.String("another-storage-class"),
+				},
 			},
 		},
 	})

--- a/service/ocean/spark/cluster.go
+++ b/service/ocean/spark/cluster.go
@@ -31,6 +31,14 @@ type Config struct {
 	Compute       *ComputeConfig       `json:"compute,omitempty"`
 	LogCollection *LogCollectionConfig `json:"logCollection,omitempty"`
 	Spark         *SparkConfig         `json:"spark,omitempty"`
+	Workspaces    *WorkspacesConfig    `json:"workspaces,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+type WorkspacesConfig struct {
+	StorageClassOverride *string `json:"storageClassOverride,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -191,6 +199,13 @@ func (c Config) MarshalJSON() ([]byte, error) {
 func (c *Config) SetIngress(v *IngressConfig) *Config {
 	if c.Ingress = v; c.Ingress == nil {
 		c.nullFields = append(c.nullFields, "Ingress")
+	}
+	return c
+}
+
+func (c *Config) SetWorkspaces(v *WorkspacesConfig) *Config {
+	if c.Workspaces = v; c.Workspaces == nil {
+		c.nullFields = append(c.nullFields, "Workspaces")
 	}
 	return c
 }
@@ -441,6 +456,23 @@ func (l *LogCollectionConfig) SetCollectAppLogs(v *bool) *LogCollectionConfig {
 		l.nullFields = append(l.nullFields, "CollectAppLogs")
 	}
 	return l
+}
+
+// endregion
+
+// region Workspaces
+
+func (w WorkspacesConfig) MarshalJSON() ([]byte, error) {
+	type noMethod WorkspacesConfig
+	raw := noMethod(w)
+	return jsonutil.MarshalJSON(raw, w.forceSendFields, w.nullFields)
+}
+
+func (w *WorkspacesConfig) SetStorageClassOverride(v *string) *WorkspacesConfig {
+	if w.StorageClassOverride = v; w.StorageClassOverride == nil {
+		w.nullFields = append(w.nullFields, "StorageClassOverride")
+	}
+	return w
 }
 
 // endregion


### PR DESCRIPTION
[BGD-6259](https://spotinst.atlassian.net/browse/BGD-6259)

Added a new object to the config with an optional property for setting a storage class override for workspaces.

[BGD-6259]: https://spotinst.atlassian.net/browse/BGD-6259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ