### PR TITLE
Added `ScalingOrientation` field in `strategy` object for ocean-gcp-k8s

### DIFF
--- a/service/ocean/providers/gcp/cluster.go
+++ b/service/ocean/providers/gcp/cluster.go
@@ -51,6 +51,7 @@ type Strategy struct {
 	ProvisioningModel        *string `json:"provisioningModel,omitempty"`
 	PreemptiblePercentage    *int    `json:"preemptiblePercentage,omitempty"`
 	ShouldUtilizeCommitments *bool   `json:"shouldUtilizeCommitments,omitempty"`
+	ScalingOrientation       *string `json:"scalingOrientation,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -918,6 +919,13 @@ func (o *Strategy) SetPreemptiblePercentage(v *int) *Strategy {
 func (o *Strategy) SetShouldUtilizeCommitments(v *bool) *Strategy {
 	if o.ShouldUtilizeCommitments = v; o.ShouldUtilizeCommitments == nil {
 		o.nullFields = append(o.nullFields, "ShouldUtilizeCommitments")
+	}
+	return o
+}
+
+func (o *Strategy) SetScalingOrientation(v *string) *Strategy {
+	if o.ScalingOrientation = v; o.ScalingOrientation == nil {
+		o.nullFields = append(o.nullFields, "ScalingOrientation")
 	}
 	return o
 }

--- a/service/ocean/providers/gcp/launchspec.go
+++ b/service/ocean/providers/gcp/launchspec.go
@@ -88,7 +88,8 @@ type AutoScaleHeadroom struct {
 }
 
 type LaunchSpecStrategy struct {
-	PreemptiblePercentage *int `json:"preemptiblePercentage,omitempty"`
+	PreemptiblePercentage *int    `json:"preemptiblePercentage,omitempty"`
+	ScalingOrientation    *string `json:"scalingOrientation,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -693,6 +694,13 @@ func (o LaunchSpecStrategy) MarshalJSON() ([]byte, error) {
 func (o *LaunchSpecStrategy) SetPreemptiblePercentage(v *int) *LaunchSpecStrategy {
 	if o.PreemptiblePercentage = v; o.PreemptiblePercentage == nil {
 		o.nullFields = append(o.nullFields, "PreemptiblePercentage")
+	}
+	return o
+}
+
+func (o *LaunchSpecStrategy) SetScalingOrientation(v *string) *LaunchSpecStrategy {
+	if o.ScalingOrientation = v; o.ScalingOrientation == nil {
+		o.nullFields = append(o.nullFields, "ScalingOrientation")
 	}
 	return o
 }


### PR DESCRIPTION
Added `ScalingOrientation` field in `Strategy` object for ocean-gcp-k8s and vng

https://spotinst.atlassian.net/browse/SI-268