### PR TITLE
added `EncryptionAtHost` field in `security` object

### DIFF
--- a/service/elastigroup/providers/azure/v3/azure.go
+++ b/service/elastigroup/providers/azure/v3/azure.go
@@ -385,6 +385,7 @@ type Security struct {
 	SecureBootEnabled            *bool   `json:"secureBootEnabled,omitempty"`
 	SecurityType                 *string `json:"securityType,omitempty"`
 	VTpmEnabled                  *bool   `json:"vTpmEnabled,omitempty"`
+	EncryptionAtHost             *bool   `json:"encryptionAtHost,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -2137,6 +2138,13 @@ func (o *Security) SetSecurityType(v *string) *Security {
 func (o *Security) SetVTpmEnabled(v *bool) *Security {
 	if o.VTpmEnabled = v; o.VTpmEnabled == nil {
 		o.nullFields = append(o.nullFields, "VTpmEnabled")
+	}
+	return o
+}
+
+func (o *Security) SetEncryptionAtHost(v *bool) *Security {
+	if o.EncryptionAtHost = v; o.EncryptionAtHost == nil {
+		o.nullFields = append(o.nullFields, "EncryptionAtHost")
 	}
 	return o
 }


### PR DESCRIPTION
https://spotinst.atlassian.net/browse/SI-330

added `EncryptionAtHost` field in `security` object for Azure Elastigroup

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
