### PR TITLE
added StartupTaints support for ocean aws k8s and vng

### DIFF
--- a/service/ocean/providers/aws/cluster.go
+++ b/service/ocean/providers/aws/cluster.go
@@ -221,6 +221,7 @@ type LaunchSpecification struct {
 	ResourceTagSpecification                      *ResourceTagSpecification     `json:"resourceTagSpecification,omitempty"`
 	ReservedENIs                                  *int                          `json:"reservedENIs,omitempty"`
 	InstanceStorePolicy                           *InstanceStorePolicy          `json:"instanceStorePolicy,omitempty"`
+	StartupTaints                                 []*StartupTaints              `json:"startupTaints,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1703,6 +1704,13 @@ func (o *LaunchSpecification) SetReservedENIs(v *int) *LaunchSpecification {
 func (o *LaunchSpecification) SetInstanceStorePolicy(v *InstanceStorePolicy) *LaunchSpecification {
 	if o.InstanceStorePolicy = v; o.InstanceStorePolicy == nil {
 		o.nullFields = append(o.nullFields, "InstanceStorePolicy")
+	}
+	return o
+}
+
+func (o *LaunchSpecification) SetStartupTaints(v []*StartupTaints) *LaunchSpecification {
+	if o.StartupTaints = v; o.StartupTaints == nil {
+		o.nullFields = append(o.nullFields, "StartupTaints")
 	}
 	return o
 }

--- a/service/ocean/providers/aws/common.go
+++ b/service/ocean/providers/aws/common.go
@@ -53,3 +53,39 @@ func (o *InstanceStorePolicy) SetInstanceStorePolicyType(v *string) *InstanceSto
 	}
 	return o
 }
+
+type StartupTaints struct {
+	Key    *string `json:"key,omitempty"`
+	Value  *string `json:"value,omitempty"`
+	Effect *string `json:"effect,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+func (o StartupTaints) MarshalJSON() ([]byte, error) {
+	type noMethod StartupTaints
+	raw := noMethod(o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+func (o *StartupTaints) SetKey(v *string) *StartupTaints {
+	if o.Key = v; o.Key == nil {
+		o.nullFields = append(o.nullFields, "Key")
+	}
+	return o
+}
+
+func (o *StartupTaints) SetValue(v *string) *StartupTaints {
+	if o.Value = v; o.Value == nil {
+		o.nullFields = append(o.nullFields, "Value")
+	}
+	return o
+}
+
+func (o *StartupTaints) SetEffect(v *string) *StartupTaints {
+	if o.Effect = v; o.Effect == nil {
+		o.nullFields = append(o.nullFields, "Effect")
+	}
+	return o
+}

--- a/service/ocean/providers/aws/launchspec.go
+++ b/service/ocean/providers/aws/launchspec.go
@@ -44,6 +44,7 @@ type LaunchSpec struct {
 	PreferredOnDemandTypes   []string                           `json:"preferredOnDemandTypes,omitempty"`
 	ReservedENIs             *int                               `json:"reservedENIs,omitempty"`
 	InstanceStorePolicy      *InstanceStorePolicy               `json:"instanceStorePolicy,omitempty"`
+	StartupTaints            []*StartupTaints                   `json:"startupTaints,omitempty"`
 
 	// Read-only fields.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
@@ -717,6 +718,13 @@ func (o *LaunchSpec) SetReservedENIs(v *int) *LaunchSpec {
 func (o *LaunchSpec) SetInstanceStorePolicy(v *InstanceStorePolicy) *LaunchSpec {
 	if o.InstanceStorePolicy = v; o.InstanceStorePolicy == nil {
 		o.nullFields = append(o.nullFields, "InstanceStorePolicy")
+	}
+	return o
+}
+
+func (o *LaunchSpec) SetStartupTaints(v []*StartupTaints) *LaunchSpec {
+	if o.StartupTaints = v; o.StartupTaints == nil {
+		o.nullFields = append(o.nullFields, "StartupTaints")
 	}
 	return o
 }


### PR DESCRIPTION
added StartupTaints support for ocean aws k8s and vng

https://spotinst.atlassian.net/browse/SI-339

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
