### PR TITLE
removed `shouldPersistVm` field from azure statefulnode

### DIFF
--- a/service/stateful/providers/azure/statefulNode.go
+++ b/service/stateful/providers/azure/statefulNode.go
@@ -368,7 +368,6 @@ type Persistence struct {
 	ShouldPersistDataDisks   *bool   `json:"shouldPersistDataDisks,omitempty"`
 	DataDisksPersistenceMode *string `json:"dataDisksPersistenceMode,omitempty"`
 	ShouldPersistNetwork     *bool   `json:"shouldPersistNetwork,omitempty"`
-	ShouldPersistVM          *bool   `json:"shouldPersistVm,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1184,13 +1183,6 @@ func (o *Persistence) SetDataDisksPersistenceMode(v *string) *Persistence {
 func (o *Persistence) SetShouldPersistNetwork(v *bool) *Persistence {
 	if o.ShouldPersistNetwork = v; o.ShouldPersistNetwork == nil {
 		o.nullFields = append(o.nullFields, "ShouldPersistNetwork")
-	}
-	return o
-}
-
-func (o *Persistence) SetShouldPersistVM(v *bool) *Persistence {
-	if o.ShouldPersistVM = v; o.ShouldPersistVM == nil {
-		o.nullFields = append(o.nullFields, "ShouldPersistVm")
 	}
 	return o
 }


### PR DESCRIPTION
removed `shouldPersistVm` field from azure statefulnode

https://spotinst.atlassian.net/browse/SI-351
# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
