### PR TITLE
added support for `subscriptionId` field in azure stateful node

### DIFF
--- a/service/stateful/providers/azure/statefulNode.go
+++ b/service/stateful/providers/azure/statefulNode.go
@@ -208,6 +208,7 @@ type Tag struct {
 type ManagedServiceIdentity struct {
 	Name              *string `json:"name,omitempty"`
 	ResourceGroupName *string `json:"resourceGroupName,omitempty"`
+	SubscriptionID    *string `json:"subscriptionId,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1731,6 +1732,13 @@ func (o *ManagedServiceIdentity) SetName(v *string) *ManagedServiceIdentity {
 func (o *ManagedServiceIdentity) SetResourceGroupName(v *string) *ManagedServiceIdentity {
 	if o.ResourceGroupName = v; o.ResourceGroupName == nil {
 		o.nullFields = append(o.nullFields, "ResourceGroupName")
+	}
+	return o
+}
+
+func (o *ManagedServiceIdentity) SetSubscriptionID(v *string) *ManagedServiceIdentity {
+	if o.SubscriptionID = v; o.SubscriptionID == nil {
+		o.nullFields = append(o.nullFields, "SubscriptionID")
 	}
 	return o
 }


### PR DESCRIPTION
added support for `subscriptionId` field in azure stateful node

https://spotinst.atlassian.net/browse/SI-373

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
