### PR TITLE
added `primaryIpv6` feild in ocean aws

### DIFF
--- a/service/ocean/providers/aws/cluster.go
+++ b/service/ocean/providers/aws/cluster.go
@@ -222,6 +222,7 @@ type LaunchSpecification struct {
 	ReservedENIs                                  *int                          `json:"reservedENIs,omitempty"`
 	InstanceStorePolicy                           *InstanceStorePolicy          `json:"instanceStorePolicy,omitempty"`
 	StartupTaints                                 []*StartupTaints              `json:"startupTaints,omitempty"`
+	PrimaryIPv6                                   *bool                         `json:"primaryIpv6,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -1711,6 +1712,13 @@ func (o *LaunchSpecification) SetInstanceStorePolicy(v *InstanceStorePolicy) *La
 func (o *LaunchSpecification) SetStartupTaints(v []*StartupTaints) *LaunchSpecification {
 	if o.StartupTaints = v; o.StartupTaints == nil {
 		o.nullFields = append(o.nullFields, "StartupTaints")
+	}
+	return o
+}
+
+func (o *LaunchSpecification) SetPrimaryIPv6(v *bool) *LaunchSpecification {
+	if o.PrimaryIPv6 = v; o.PrimaryIPv6 == nil {
+		o.nullFields = append(o.nullFields, "PrimaryIPv6")
 	}
 	return o
 }


### PR DESCRIPTION
added `primaryIpv6` feild in ocean aws

https://spotinst.atlassian.net/browse/SI-387

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
