### PR TITLE
added `filters` object in common to support filtering instanceTypes in launchSpec

### DIFF
--- a/service/ocean/providers/gcp/cluster.go
+++ b/service/ocean/providers/gcp/cluster.go
@@ -197,18 +197,6 @@ type InstanceTypes struct {
 	nullFields      []string
 }
 
-type Filters struct {
-	ExcludeFamilies []string `json:"excludeFamilies,omitempty"`
-	IncludeFamilies []string `json:"includeFamilies,omitempty"`
-	MaxMemoryGiB    *float64 `json:"maxMemoryGiB,omitempty"`
-	MaxVcpu         *int     `json:"maxVcpu,omitempty"`
-	MinMemoryGiB    *float64 `json:"minMemoryGiB,omitempty"`
-	MinVcpu         *int     `json:"minVcpu,omitempty"`
-
-	forceSendFields []string
-	nullFields      []string
-}
-
 type LaunchSpecification struct {
 	Labels                 []*Label                          `json:"labels,omitempty"`
 	IPForwarding           *bool                             `json:"ipForwarding,omitempty"`
@@ -1009,54 +997,6 @@ func (o *InstanceTypes) SetPreferredTypes(v []string) *InstanceTypes {
 func (o *InstanceTypes) SetFilters(v *Filters) *InstanceTypes {
 	if o.Filters = v; o.Filters == nil {
 		o.nullFields = append(o.nullFields, "Filters")
-	}
-	return o
-}
-
-func (o Filters) MarshalJSON() ([]byte, error) {
-	type noMethod Filters
-	raw := noMethod(o)
-	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
-}
-
-func (o *Filters) SetExcludeFamilies(v []string) *Filters {
-	if o.ExcludeFamilies = v; o.ExcludeFamilies == nil {
-		o.nullFields = append(o.nullFields, "ExcludeFamilies")
-	}
-	return o
-}
-
-func (o *Filters) SetIncludeFamilies(v []string) *Filters {
-	if o.IncludeFamilies = v; o.IncludeFamilies == nil {
-		o.nullFields = append(o.nullFields, "IncludeFamilies")
-	}
-	return o
-}
-
-func (o *Filters) SetMaxMemoryGiB(v *float64) *Filters {
-	if o.MaxMemoryGiB = v; o.MaxMemoryGiB == nil {
-		o.nullFields = append(o.nullFields, "MaxMemoryGiB")
-	}
-	return o
-}
-
-func (o *Filters) SetMaxVcpu(v *int) *Filters {
-	if o.MaxVcpu = v; o.MaxVcpu == nil {
-		o.nullFields = append(o.nullFields, "MaxVcpu")
-	}
-	return o
-}
-
-func (o *Filters) SetMinMemoryGiB(v *float64) *Filters {
-	if o.MinMemoryGiB = v; o.MinMemoryGiB == nil {
-		o.nullFields = append(o.nullFields, "MinMemoryGiB")
-	}
-	return o
-}
-
-func (o *Filters) SetMinVcpu(v *int) *Filters {
-	if o.MinVcpu = v; o.MinVcpu == nil {
-		o.nullFields = append(o.nullFields, "MinVcpu")
 	}
 	return o
 }

--- a/service/ocean/providers/gcp/common.go
+++ b/service/ocean/providers/gcp/common.go
@@ -32,4 +32,64 @@ func (o *Tag) SetValue(v *string) *Tag {
 	return o
 }
 
+type Filters struct {
+	ExcludeFamilies []string `json:"excludeFamilies,omitempty"`
+	IncludeFamilies []string `json:"includeFamilies,omitempty"`
+	MaxMemoryGiB    *float64 `json:"maxMemoryGiB,omitempty"`
+	MaxVcpu         *int     `json:"maxVcpu,omitempty"`
+	MinMemoryGiB    *float64 `json:"minMemoryGiB,omitempty"`
+	MinVcpu         *int     `json:"minVcpu,omitempty"`
+
+	forceSendFields []string
+	nullFields      []string
+}
+
+func (o Filters) MarshalJSON() ([]byte, error) {
+	type noMethod Filters
+	raw := noMethod(o)
+	return jsonutil.MarshalJSON(raw, o.forceSendFields, o.nullFields)
+}
+
+func (o *Filters) SetExcludeFamilies(v []string) *Filters {
+	if o.ExcludeFamilies = v; o.ExcludeFamilies == nil {
+		o.nullFields = append(o.nullFields, "ExcludeFamilies")
+	}
+	return o
+}
+
+func (o *Filters) SetIncludeFamilies(v []string) *Filters {
+	if o.IncludeFamilies = v; o.IncludeFamilies == nil {
+		o.nullFields = append(o.nullFields, "IncludeFamilies")
+	}
+	return o
+}
+
+func (o *Filters) SetMaxMemoryGiB(v *float64) *Filters {
+	if o.MaxMemoryGiB = v; o.MaxMemoryGiB == nil {
+		o.nullFields = append(o.nullFields, "MaxMemoryGiB")
+	}
+	return o
+}
+
+func (o *Filters) SetMaxVcpu(v *int) *Filters {
+	if o.MaxVcpu = v; o.MaxVcpu == nil {
+		o.nullFields = append(o.nullFields, "MaxVcpu")
+	}
+	return o
+}
+
+func (o *Filters) SetMinMemoryGiB(v *float64) *Filters {
+	if o.MinMemoryGiB = v; o.MinMemoryGiB == nil {
+		o.nullFields = append(o.nullFields, "MinMemoryGiB")
+	}
+	return o
+}
+
+func (o *Filters) SetMinVcpu(v *int) *Filters {
+	if o.MinVcpu = v; o.MinVcpu == nil {
+		o.nullFields = append(o.nullFields, "MinVcpu")
+	}
+	return o
+}
+
 // endregion

--- a/service/ocean/providers/gcp/launchspec.go
+++ b/service/ocean/providers/gcp/launchspec.go
@@ -34,6 +34,7 @@ type LaunchSpec struct {
 	LaunchSpecScheduling        *GKELaunchSpecScheduling       `json:"scheduling,omitempty"`
 	LaunchSpecTags              []string                       `json:"tags,omitempty"`
 	LaunchSpecNetworkInterfaces []*LaunchSpecNetworkInterfaces `json:"networkInterfaces,omitempty"`
+	Filters                     *Filters                       `json:"filters,omitempty"`
 
 	// forceSendFields is a list of field names (e.g. "Keys") to
 	// unconditionally include in API requests. By default, fields with
@@ -887,6 +888,13 @@ func (o *GKELaunchSpecTaskHeadroom) SetNumOfUnits(v *int) *GKELaunchSpecTaskHead
 func (o *LaunchSpec) SetLaunchSpecNetworkInterfaces(v []*LaunchSpecNetworkInterfaces) *LaunchSpec {
 	if o.LaunchSpecNetworkInterfaces = v; o.LaunchSpecNetworkInterfaces == nil {
 		o.nullFields = append(o.nullFields, "LaunchSpecNetworkInterfaces")
+	}
+	return o
+}
+
+func (o *LaunchSpec) SetFilters(v *Filters) *LaunchSpec {
+	if o.Filters = v; o.Filters == nil {
+		o.nullFields = append(o.nullFields, "Filters")
 	}
 	return o
 }


### PR DESCRIPTION
added `filters` object in common to support filtering instanceTypes in launchSpec

https://spotinst.atlassian.net/browse/SI-396

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
