### PR TITLE
added `downsideOnly` field to rightSizing

### DIFF
--- a/service/ocean/right_sizing/right_sizing.go
+++ b/service/ocean/right_sizing/right_sizing.go
@@ -22,6 +22,7 @@ type RightsizingRule struct {
 	RecommendationApplicationOverheadValues *RecommendationApplicationOverheadValues `json:"recommendationApplicationOverheadValues,omitempty"`
 	RecommendationApplicationHPA            *RecommendationApplicationHPA            `json:"recommendationApplicationHPA,omitempty"`
 	AutoApplyDefinition                     *AutoApplyDefinition                     `json:"autoApplyDefinition,omitempty"`
+	DownsideOnly                            *bool                                    `json:"downsideOnly,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -598,6 +599,13 @@ func (o *RightsizingRule) SetRecommendationApplicationHPA(v *RecommendationAppli
 func (o *RightsizingRule) SetAutoApplyDefinition(v *AutoApplyDefinition) *RightsizingRule {
 	if o.AutoApplyDefinition = v; o.AutoApplyDefinition == nil {
 		o.nullFields = append(o.nullFields, "AutoApplyDefinition")
+	}
+	return o
+}
+
+func (o *RightsizingRule) SetDownsideOnly(v *bool) *RightsizingRule {
+	if o.DownsideOnly = v; o.DownsideOnly == nil {
+		o.nullFields = append(o.nullFields, "DownsideOnly")
 	}
 	return o
 }


### PR DESCRIPTION
added `downsideOnly` field to automation rightSizing

https://flexera.atlassian.net/browse/SI-401
# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
