### PR TITLE
Sptaut 19543 fr terraform ocean azure support for should replace unhealthy instances in spotinst ocean aks np

### DIFF
--- a/service/ocean/providers/azure_np/cluster_np.go
+++ b/service/ocean/providers/azure_np/cluster_np.go
@@ -53,7 +53,9 @@ type AutoScaler struct {
 }
 
 type Health struct {
-	GracePeriod *int `json:"gracePeriod,omitempty"`
+	GracePeriod                                   *int  `json:"gracePeriod,omitempty"`
+	ShouldReplaceUnhealthyInstances               *bool `json:"shouldReplaceUnhealthyInstances,omitempty"`
+	HealthCheckUnhealthyDurationBeforeReplacement *int  `json:"healthCheckUnhealthyDurationBeforeReplacement,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -794,6 +796,20 @@ func (o Health) MarshalJSON() ([]byte, error) {
 func (o *Health) SetGracePeriod(v *int) *Health {
 	if o.GracePeriod = v; o.GracePeriod == nil {
 		o.nullFields = append(o.nullFields, "GracePeriod")
+	}
+	return o
+}
+
+func (o *Health) SetShouldReplaceUnhealthyInstances(v *bool) *Health {
+	if o.ShouldReplaceUnhealthyInstances = v; o.ShouldReplaceUnhealthyInstances == nil {
+		o.nullFields = append(o.nullFields, "ShouldReplaceUnhealthyInstances")
+	}
+	return o
+}
+
+func (o *Health) SetHealthCheckUnhealthyDurationBeforeReplacement(v *int) *Health {
+	if o.HealthCheckUnhealthyDurationBeforeReplacement = v; o.HealthCheckUnhealthyDurationBeforeReplacement == nil {
+		o.nullFields = append(o.nullFields, "HealthCheckUnhealthyDurationBeforeReplacement")
 	}
 	return o
 }

--- a/service/ocean/providers/azure_np/common.go
+++ b/service/ocean/providers/azure_np/common.go
@@ -160,9 +160,10 @@ func (o *NodeCountLimits) SetMaxCount(v *int) *NodeCountLimits {
 
 // Strategy region
 type Strategy struct {
-	SpotPercentage  *int  `json:"spotPercentage,omitempty"`
-	FallbackToOD    *bool `json:"fallbackToOd,omitempty"`
-	DrainingTimeout *int  `json:"drainingTimeout,omitempty"`
+	SpotPercentage           *int  `json:"spotPercentage,omitempty"`
+	FallbackToOD             *bool `json:"fallbackToOd,omitempty"`
+	DrainingTimeout          *int  `json:"drainingTimeout,omitempty"`
+	ShouldUtilizeCommitments *bool `json:"shouldUtilizeCommitments,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -191,6 +192,13 @@ func (o *Strategy) SetFallbackToOD(v *bool) *Strategy {
 func (o *Strategy) SetDrainingTimeout(v *int) *Strategy {
 	if o.DrainingTimeout = v; o.DrainingTimeout == nil {
 		o.nullFields = append(o.nullFields, "DrainingTimeout")
+	}
+	return o
+}
+
+func (o *Strategy) SetShouldUtilizeCommitments(v *bool) *Strategy {
+	if o.ShouldUtilizeCommitments = v; o.ShouldUtilizeCommitments == nil {
+		o.nullFields = append(o.nullFields, "ShouldUtilizeCommitments")
 	}
 	return o
 }


### PR DESCRIPTION
feat(ocean Azure/cluster/VNG): Added support for ShouldUtilizeCommitments under Strategy Object.
feat(ocean Azure/cluster): Added support for shouldReplaceUnhealthyInstances, healthCheckUnhealthyDurationBeforeReplacement under Health Object.

https://flexera.atlassian.net/browse/SPTAUT-19543
https://flexera.atlassian.net/browse/SPTAUT-19548
https://flexera.atlassian.net/browse/SPTAUT-19562