### PR TITLE
feat(ocean GCP/launchspec): Added support for LocalNvmeSsdCount and LocalSsdEphemeralStorageCount under Storage Object.

### DIFF
--- a/service/ocean/providers/aws/cluster.go
+++ b/service/ocean/providers/aws/cluster.go
@@ -48,16 +48,17 @@ type Cluster struct {
 }
 
 type Strategy struct {
-	SpotPercentage           *float64            `json:"spotPercentage,omitempty"`
-	UtilizeReservedInstances *bool               `json:"utilizeReservedInstances,omitempty"`
-	FallbackToOnDemand       *bool               `json:"fallbackToOd,omitempty"`
-	DrainingTimeout          *int                `json:"drainingTimeout,omitempty"`
-	GracePeriod              *int                `json:"gracePeriod,omitempty"`
-	UtilizeCommitments       *bool               `json:"utilizeCommitments,omitempty"`
-	ClusterOrientation       *ClusterOrientation `json:"clusterOrientation,omitempty"`
-	SpreadNodesBy            *string             `json:"spreadNodesBy,omitempty"`
-	forceSendFields          []string
-	nullFields               []string
+	SpotPercentage                *float64            `json:"spotPercentage,omitempty"`
+	UtilizeReservedInstances      *bool               `json:"utilizeReservedInstances,omitempty"`
+	FallbackToOnDemand            *bool               `json:"fallbackToOd,omitempty"`
+	DrainingTimeout               *int                `json:"drainingTimeout,omitempty"`
+	GracePeriod                   *int                `json:"gracePeriod,omitempty"`
+	MaxReplacementLimitPercentage *int                `json:"maxReplacementLimitPercentage,omitempty"`
+	UtilizeCommitments            *bool               `json:"utilizeCommitments,omitempty"`
+	ClusterOrientation            *ClusterOrientation `json:"clusterOrientation,omitempty"`
+	SpreadNodesBy                 *string             `json:"spreadNodesBy,omitempty"`
+	forceSendFields               []string
+	nullFields                    []string
 }
 type ClusterOrientation struct {
 	AvailabilityVsCost *string `json:"availabilityVsCost,omitempty"`
@@ -1282,6 +1283,13 @@ func (o *Strategy) SetDrainingTimeout(v *int) *Strategy {
 func (o *Strategy) SetGracePeriod(v *int) *Strategy {
 	if o.GracePeriod = v; o.GracePeriod == nil {
 		o.nullFields = append(o.nullFields, "GracePeriod")
+	}
+	return o
+}
+
+func (o *Strategy) SetMaxReplacementLimitPercentage(v *int) *Strategy {
+	if o.MaxReplacementLimitPercentage = v; o.MaxReplacementLimitPercentage == nil {
+		o.nullFields = append(o.nullFields, "MaxReplacementLimitPercentage")
 	}
 	return o
 }

--- a/service/ocean/providers/gcp/launchspec.go
+++ b/service/ocean/providers/gcp/launchspec.go
@@ -105,7 +105,9 @@ type ShieldedInstanceConfig struct {
 }
 
 type Storage struct {
-	LocalSSDCount *int `json:"localSsdCount,omitempty"`
+	LocalSSDCount                 *int `json:"localSsdCount,omitempty"`
+	LocalNvmeSsdCount             *int `json:"localNvmeSsdCount,omitempty"`
+	LocalSsdEphemeralStorageCount *int `json:"localSsdEphemeralStorageCount,omitempty"`
 
 	forceSendFields []string
 	nullFields      []string
@@ -743,6 +745,20 @@ func (o Storage) MarshalJSON() ([]byte, error) {
 func (o *Storage) SetLocalSSDCount(v *int) *Storage {
 	if o.LocalSSDCount = v; o.LocalSSDCount == nil {
 		o.nullFields = append(o.nullFields, "LocalSSDCount")
+	}
+	return o
+}
+
+func (o *Storage) SetLocalNvmeSsdCount(v *int) *Storage {
+	if o.LocalNvmeSsdCount = v; o.LocalNvmeSsdCount == nil {
+		o.nullFields = append(o.nullFields, "LocalNvmeSsdCount")
+	}
+	return o
+}
+
+func (o *Storage) SetLocalSsdEphemeralStorageCount(v *int) *Storage {
+	if o.LocalSsdEphemeralStorageCount = v; o.LocalSsdEphemeralStorageCount == nil {
+		o.nullFields = append(o.nullFields, "LocalSsdEphemeralStorageCount")
 	}
 	return o
 }


### PR DESCRIPTION
feat(ocean GCP/launchspec): Added support for LocalNvmeSsdCount and LocalSsdEphemeralStorageCount under Storage Object.

feat(ocean AWS/cluster): Added support for MaxReplacementLimitPercentage under Strategy Object.

https://flexera.atlassian.net/browse/SPTAUT-19589
https://flexera.atlassian.net/browse/SPTAUT-19587
